### PR TITLE
feat: replace golint with golangci-lint

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -10,11 +10,11 @@ RUN zypper -n install gcc gzip tar wget  && \
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm64=arm64 GOLANG_ARCH_s390x=s390x GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.20.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go install golang.org/x/lint/golint@latest
+RUN wget -O - https://storage.googleapis.com/golang/go1.20.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
 
 ENV DAPPER_RUN_ARGS --privileged
-ENV DAPPER_ENV REPO TAG DRONE_TAG
+ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_REPO DRONE_PULL_REQUEST DRONE_COMMIT_REF
 ENV DAPPER_SOURCE /go/src/github.com/longhorn/go-common-libs/
 ENV DAPPER_OUTPUT coverage.out
 ENV DAPPER_DOCKER_SOCKET true

--- a/scripts/validate
+++ b/scripts/validate
@@ -10,13 +10,21 @@ PACKAGES="$(go list ./...)"
 echo Running: go vet
 go vet ${PACKAGES}
 
-echo Running: golint
-for i in ${PACKAGES}; do
-  if [ -n "$(golint $i | grep -v 'should have comment.*or be unexported' | grep -v 'just return error instead.' | tee /dev/stderr)" ]; then
-    failed=true
-  fi
-done
-test -z "$failed"
+if [ ! -z "${DRONE_REPO}" ] && [ ! -z "${DRONE_PULL_REQUEST}" ]; then
+	wget https://github.com/$DRONE_REPO/pull/$DRONE_PULL_REQUEST.patch
+	echo "Running: golangci-lint run --new-from-patch=${DRONE_PULL_REQUEST}.patch"
+	golangci-lint run --new-from-patch="${DRONE_PULL_REQUEST}.patch"
+	rm "${DRONE_PULL_REQUEST}.patch"
+elif [ ! -z "${DRONE_COMMIT_REF}" ]; then
+	echo "Running: golangci-lint run --new-from-rev=${DRONE_COMMIT_REF}"
+	golangci-lint run --new-from-rev=${DRONE_COMMIT_REF}
+else
+	git symbolic-ref -q HEAD && REV="origin/HEAD" || REV="HEAD^"
+	headSHA=$(git rev-parse --short=12 ${REV})
+	echo "Running: golangci-lint run --new-from-rev=${headSHA}"
+	golangci-lint run --new-from-rev=${headSHA}
+fi
+
 
 echo Running: go fmt
 test -z "$(go fmt ${PACKAGES} | tee /dev/stderr)"


### PR DESCRIPTION
issue: https://github.com/longhorn/longhorn/issues/7366

Using `golangci-lint run --new-from-rev=` or `golangci-lint run --new-from-patch=` because there are too many warning for current code.

Ref: https://golangci-lint.run/usage/faq/#how-to-integrate-golangci-lint-into-large-project-with-thousands-of-issues