### PR TITLE
Add Driver in DiskStat struct

### DIFF
--- a/io/file.go
+++ b/io/file.go
@@ -233,6 +233,7 @@ func GetDiskStat(path string) (diskStat types.DiskStat, err error) {
 		DiskID:           fsidFormatted,
 		Path:             path,
 		Type:             usage.Fstype,
+		Driver:           types.DiskDriverNone,
 		FreeBlocks:       int64(statfs.Bfree),
 		TotalBlocks:      int64(statfs.Blocks),
 		BlockSize:        statfs.Bsize,

--- a/io/file_test.go
+++ b/io/file_test.go
@@ -606,6 +606,7 @@ func getDiskStat(path string) (*types.DiskStat, error) {
 		DiskID:           fsStat.Fsid,
 		Path:             fsStat.Path,
 		Type:             fsStat.Type,
+		Driver:           types.DiskDriverNone,
 		FreeBlocks:       fsStat.FreeBlock,
 		TotalBlocks:      fsStat.TotalBlock,
 		BlockSize:        fsStat.BlockSize,

--- a/types/file.go
+++ b/types/file.go
@@ -6,10 +6,22 @@ import (
 
 var FileLockDefaultTimeout = 24 * time.Hour
 
+type DiskDriver string
+
+const (
+	DiskDriverNone       = DiskDriver("")
+	DiskDriverAio        = DiskDriver("aio")
+	DiskDriverNvme       = DiskDriver("nvme")
+	DiskDriverVirtioScsi = DiskDriver("virtio-scsi")
+	DiskDriverVirtioBlk  = DiskDriver("virtio-blk")
+)
+
 type DiskStat struct {
 	DiskID           string
+	Name             string
 	Path             string
 	Type             string
+	Driver           DiskDriver
 	FreeBlocks       int64
 	TotalBlocks      int64
 	BlockSize        int64


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7672

#### What this PR does / why we need it:

Driver field will be used for block-type disk such as https://github.com/longhorn/longhorn-manager/blob/master/controller/monitor/disk_utils.go#L48-L56.

#### Special notes for your reviewer:

#### Additional documentation or context
