### PR TITLE
fix(profiler): data race accessing s.server

### DIFF
--- a/ns/filelock.go
+++ b/ns/filelock.go
@@ -40,7 +40,7 @@ func LockFile(path string) (result *os.File, err error) {
 // FileLock is a struct responsible for locking a file.
 type FileLock struct {
 	FilePath string        // The path of the file to lock.
-	File     *os.File      // The file handle aquired after successful lock.
+	File     *os.File      // The file handle acquired after successful lock.
 	Timeout  time.Duration // The maximum time to wait for lock acquisition.
 
 	done  chan struct{} // A channel for signaling lock release.

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -164,33 +164,46 @@ func (s *Server) EnableProfiler(portNumber int32) (string, error) {
 	}
 
 	profilerAddr := fmt.Sprintf(":%d", profilerPort)
-	s.server = &http.Server{
+	newServer := &http.Server{
 		Addr:              profilerAddr,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	go func() {
-		if err := s.server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			logrus.WithError(err).Warnf("Get error when start profiler server %v", s.server.Addr)
-			s.server = nil
+		if err := newServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			logrus.WithError(err).Warnf("Get error when start profiler server %v", newServer.Addr)
 			s.errMsg = err.Error()
 			return
 		}
-		logrus.Infof("Profiler server (%v) is closed", s.server.Addr)
+		logrus.Infof("Profiler server (%v) is closed", newServer.Addr)
 	}()
 
-	logrus.Infof("Waiting the profiler server(%v) to start", s.server.Addr)
+	logrus.Infof("Waiting the profiler server(%v) to start", newServer.Addr)
 	// Wait for the profiler server to start, and check the profiler server.
+	var retryErr error
 	retryCount := 3
 	for i := 0; i < retryCount; i++ {
-		conn, err := net.DialTimeout("tcp", s.server.Addr, 1*time.Second)
+		conn, err := net.DialTimeout("tcp", newServer.Addr, 1*time.Second)
 		if err == nil {
 			_ = conn.Close()
+			retryErr = nil
 			break
 		}
+
+		retryErr = err
 	}
-	if s.server == nil {
+
+	if retryErr != nil {
+		_ = newServer.Close()
+		return retryErr.Error(), fmt.Errorf("timeout connecting to profiler server(%v)", profilerAddr)
+	}
+
+	if s.errMsg != "" {
+		_ = newServer.Close()
 		return s.errMsg, fmt.Errorf("failed to start profiler server(%v)", profilerAddr)
 	}
+
+	s.server = newServer
+
 	defer func() {
 		s.errMsg = ""
 	}()

--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -151,7 +151,7 @@ func (s *Server) EnableProfiler(portNumber int32) (string, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	logrus.Info("Prepareing to enable the profiler")
+	logrus.Info("Preparing to enable the profiler")
 
 	if s.server != nil {
 		return "", fmt.Errorf("profiler server is already running at %v", s.server.Addr)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue `N/A`

#### What this PR does / why we need it:

Fix the concurrent access and modification of the s.server.

#### Special notes for your reviewer:

#### Additional documentation or context

This is noticed in https://github.com/longhorn/go-common-libs/pull/12#issuecomment-1920852057, and detected by the unit testing.

```
=== RUN   Test
time="2024-02-02T01:00:24Z" level=info msg="Profiler operation: SHOW, port: 0"
time="2024-02-02T01:00:24Z" level=info msg="Preparing to show the profiler address"
time="2024-02-02T01:00:24Z" level=info msg="Profiler operation: ENABLE, port: 55555"
time="2024-02-02T01:00:24Z" level=info msg="Prepareing to enable the profiler"
time="2024-02-02T01:00:24Z" level=info msg="Waiting the profiler server(:55555) to start"
time="2024-02-02T01:00:24Z" level=info msg="Profiler operation: DISABLE, port: 55555"
time="2024-02-02T01:00:24Z" level=info msg="Preparing to disable the profiler"
time="2024-02-02T01:00:24Z" level=info msg="Profiler server (:55555) is closed"
==================
WARNING: DATA RACE
Write at 0x00c0000ae0a0 by goroutine 34:
  github.com/longhorn/go-common-libs/profiler.(*Server).DisableProfiler()
      /go-common-libs/profiler/profiler.go:218 +0x3fb
  github.com/longhorn/go-common-libs/profiler.(*Server).ProfilerOP()
      /go-common-libs/profiler/profiler.go:123 +0x229
  github.com/longhorn/go-common-libs/generated/profilerpb._Profiler_ProfilerOP_Handler()
      /go-common-libs/generated/profilerpb/profiler_grpc.pb.go:79 +0x22d
  google.golang.org/grpc.(*Server).processUnaryRPC()
      /go-common-libs/vendor/google.golang.org/grpc/server.go:1372 +0x196b
  google.golang.org/grpc.(*Server).handleStream()
      /go-common-libs/vendor/google.golang.org/grpc/server.go:1783 +0x1a31
  google.golang.org/grpc.(*Server).serveStreams.func2.1()
      /go-common-libs/vendor/google.golang.org/grpc/server.go:1016 +0xd2

Previous read at 0x00c0000ae0a0 by goroutine 28:
  github.com/longhorn/go-common-libs/profiler.(*Server).EnableProfiler.func1()
      /go-common-libs/profiler/profiler.go:178 +0x2aa

Goroutine 34 (running) created at:
  google.golang.org/grpc.(*Server).serveStreams.func2()
      /go-common-libs/vendor/google.golang.org/grpc/server.go:1027 +0x204
  google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
      /go-common-libs/vendor/google.golang.org/grpc/internal/transport/http2_server.go:603 +0x3a01
  google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
      /go-common-libs/vendor/google.golang.org/grpc/internal/transport/http2_server.go:648 +0x285
  google.golang.org/grpc.(*Server).serveStreams()
      /go-common-libs/vendor/google.golang.org/grpc/server.go:1012 +0x6bb
  google.golang.org/grpc.(*Server).handleRawConn.func1()
      /go-common-libs/vendor/google.golang.org/grpc/server.go:939 +0x86

Goroutine 28 (finished) created at:
  github.com/longhorn/go-common-libs/profiler.(*Server).EnableProfiler()
      /go-common-libs/profiler/profiler.go:171 +0x40a
  github.com/longhorn/go-common-libs/profiler.(*Server).ProfilerOP()
      /go-common-libs/profiler/profiler.go:119 +0x3aa
  github.com/longhorn/go-common-libs/generated/profilerpb._Profiler_ProfilerOP_Handler()
      /go-common-libs/generated/profilerpb/profiler_grpc.pb.go:79 +0x22d
  google.golang.org/grpc.(*Server).processUnaryRPC()
      /go-common-libs/vendor/google.golang.org/grpc/server.go:1372 +0x196b
  google.golang.org/grpc.(*Server).handleStream()
      /go-common-libs/vendor/google.golang.org/grpc/server.go:1783 +0x1a31
  google.golang.org/grpc.(*Server).serveStreams.func2.1()
      /go-common-libs/vendor/google.golang.org/grpc/server.go:1016 +0xd2
==================
PASS: <autogenerated>:1: TestSuite.TestProfilerServiceOperations        0.006s
OK: 1 passed
    testing.go:1465: race detected during execution of test
--- FAIL: Test (0.01s)
=== NAME  
    testing.go:1465: race detected during execution of test
FAIL
coverage: 76.6% of statements
FAIL    github.com/longhorn/go-common-libs/profiler     0.024s
```