### PR TITLE
feat(naming): add longhorn engine naming validation

### DIFF
--- a/utils/longhorn_naming.go
+++ b/utils/longhorn_naming.go
@@ -1,0 +1,11 @@
+package utils
+
+import (
+	"regexp"
+)
+
+// IsEngineProcess distinguish if the process is a engine process by its name.
+func IsEngineProcess(processName string) bool {
+	// engine process name example: pvc-5a8ee916-5989-46c6-bafc-ddbf7c802499-e-0
+	return regexp.MustCompile(`.+?-e-.*\d$`).MatchString(processName)
+}

--- a/utils/longhorn_naming_test.go
+++ b/utils/longhorn_naming_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/longhorn/go-common-libs/test"
+)
+
+func (s *TestSuite) TestIsEngineProcess(c *C) {
+	type testCase struct {
+		input    string
+		expected bool
+	}
+	testCases := map[string]testCase{
+		"engine": {
+			input:    "pvc-5a8ee916-5989-46c6-bafc-ddbf7c802499-e-0",
+			expected: true,
+		},
+		"engine-2": {
+			input:    "nginx-e-0",
+			expected: true,
+		},
+		"replica": {
+			input:    "nginx-r-0",
+			expected: false,
+		},
+		"invalid": {
+			input:    "invalid-string",
+			expected: false,
+		},
+		"invalid-2": {
+			input:    "-e-0",
+			expected: false,
+		},
+		"invalid-3": {
+			input:    "abc-eee-0",
+			expected: false,
+		},
+	}
+	for testName, testCase := range testCases {
+		c.Logf("testing utils.%v", testName)
+
+		result := IsEngineProcess(testCase.input)
+		c.Assert(result, Equals, testCase.expected, Commentf(test.ErrResultFmt, testName))
+	}
+}


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/7393

build a regex to distinguish if the process is a engine process