### PR TITLE
feat(backup): add backup parameter types

### DIFF
--- a/backup/types.go
+++ b/backup/types.go
@@ -1,0 +1,10 @@
+package backup
+
+type LonghornBackupMode string
+
+const (
+	LonghornBackupParameterBackupMode = "backup-mode"
+
+	LonghornBackupModeFull        = LonghornBackupMode("full")
+	LonghornBackupModeIncremental = LonghornBackupMode("incremental")
+)


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/7070

Backup parameters are used in `backupstore` and `longhorn-manager`
to prevent cycle import, we define the parameters in `go-common-lib`.
