### PR TITLE
fix: use go1.22 instead of go1.22.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/longhorn/go-common-libs
 
-go 1.22.2
+go 1.22
 
 require (
 	github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

fix https://drone-pr.longhorn.io/longhorn/go-spdk-helper/150/1/3

