### PR TITLE
misc: remove hyphens from UUID before truncating it

### DIFF
--- a/utils/misc.go
+++ b/utils/misc.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -67,7 +68,7 @@ func RandomID(randomIDLenth int) string {
 		randomIDLenth = types.RandomIDDefaultLength
 	}
 
-	uuid := UUID()
+	uuid := strings.Replace(UUID(), "-", "", -1)
 
 	if len(uuid) > randomIDLenth {
 		uuid = uuid[:randomIDLenth]

--- a/utils/misc_test.go
+++ b/utils/misc_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"strings"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/longhorn/go-common-libs/test"
@@ -158,6 +160,7 @@ func (s *TestSuite) TestRandomID(c *C) {
 
 		result := RandomID(testCase.idLength)
 		c.Assert(len(result), Equals, testCase.expectedLength, Commentf(test.ErrResultFmt, testName))
+		c.Assert(strings.Contains(result, "-"), Equals, false, Commentf(test.ErrResultFmt, testName))
 	}
 }
 


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#8551

#### What this PR does / why we need it:

Remove hyphens from UUID before truncating it in RandomID()

#### Special notes for your reviewer:

#### Additional documentation or context
