### PR TITLE
Remove deprecated grpc.Dial use, replace with grpc.NewClient

### DIFF
--- a/profiler/profiler.go
+++ b/profiler/profiler.go
@@ -80,7 +80,7 @@ func NewClient(address, name string, dialOpts ...grpc.DialOption) (*Client, erro
 		}
 	}
 	getContext := func(serviceURL string) (ClientContext, error) {
-		connection, err := grpc.Dial(serviceURL, opts...)
+		connection, err := grpc.NewClient(serviceURL, opts...)
 		if err != nil {
 			return ClientContext{}, fmt.Errorf("cannot connect to ProfilerServer %v", serviceURL)
 		}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

Fix

```
Running validation
Running: go vet
Running: golangci-lint
profiler/profiler.go:83:22: SA1019: grpc.Dial is deprecated: use NewClient instead.  Will be supported throughout 1.x. (staticcheck)
		connection, err := grpc.Dial(serviceURL, opts...)
		                   ^
time="2024-06-08T15:29:46Z" level=fatal msg="exit status 1"
make: *** [Makefile:14: ci] Error 1
```

#### Special notes for your reviewer:

#### Additional documentation or context
