### PR TITLE
feat(backupbackingimage): add backup backing image parameters

### DIFF
--- a/backup/types.go
+++ b/backup/types.go
@@ -8,3 +8,8 @@ const (
 	LonghornBackupModeFull        = LonghornBackupMode("full")
 	LonghornBackupModeIncremental = LonghornBackupMode("incremental")
 )
+
+const (
+	LonghornBackupBackingImageParameterSecret          = "secret"
+	LonghornBackupBackingImageParameterSecretNamespace = "secret-namespace"
+)


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8884

To store the `secret` and `secretNamespace` to `BackupBackingImage config`
We need to pass this information through grpc call to `backing-image-manager`
As discussed, we can use a general `parameters` to pass these meta information

Inside `parameters`, we defined the const for the fields.