### PR TITLE
fix: update engine naming regex to allow non digit ending

### DIFF
--- a/longhorn/longhorn.go
+++ b/longhorn/longhorn.go
@@ -24,5 +24,5 @@ func GetVolumeNameFromReplicaDataDirectoryName(replicaName string) (string, erro
 // IsEngineProcess distinguish if the process is a engine process by its name.
 func IsEngineProcess(processName string) bool {
 	// engine process name example: pvc-5a8ee916-5989-46c6-bafc-ddbf7c802499-e-0
-	return regexp.MustCompile(`.+?-e-[^-]*\d$`).MatchString(processName)
+	return regexp.MustCompile(`.+?-e-[^-]*$`).MatchString(processName)
 }

--- a/longhorn/longhorn_test.go
+++ b/longhorn/longhorn_test.go
@@ -67,6 +67,14 @@ func (s *TestSuite) TestIsEngineProcess(c *C) {
 			input:    "nginx-r-e-0",
 			expected: true,
 		},
+		"IsEngineProcess(...): engine-3": {
+			input:    "pvc-669e5426-8c62-42df-979d-1be22a30cd0a-e-cc7d5051",
+			expected: true,
+		},
+		"IsEngineProcess(...): engine-4": {
+			input:    "pvc-3308aae1-b3c4-4ea3-a6b8-d1fc16cea03b-e-8e24327e",
+			expected: true,
+		},
 		"IsEngineProcess(...): replica": {
 			input:    "nginx-r-0",
 			expected: false,
@@ -93,6 +101,10 @@ func (s *TestSuite) TestIsEngineProcess(c *C) {
 		},
 		"IsEngineProcess(...): invalid-5": {
 			input:    "nginx-e--0",
+			expected: false,
+		},
+		"IsEngineProcess(...): invalid-6": {
+			input:    "nginx-e-0-abcd",
 			expected: false,
 		},
 	}


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/9267

Before v1.4.x, users might have engine name like "XXXX-e-12avc" or "XXXX-e-abcd1"
We change to use "-0", "-1" starting from v1.4.4, v1.5.2
https://github.com/longhorn/longhorn-manager/pull/2180

The previous regex didn't allow "XXXX-e-12avc" which  has non digit ending
We should fix it