### PR TITLE
feat: getter of kernel and NFS mount config

### DIFF
--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -1,0 +1,97 @@
+package nfs
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/longhorn/go-common-libs/types"
+)
+
+const (
+	nfsmountGlobalSection  = "NFSMount_Global_Options"
+	nfsmountDefaultVersion = "Defaultvers"
+)
+
+// GetSystemDefaultNFSVersion reads the system default NFS version. This config can be overridden by nfsmount.conf under
+// configDir. If configDir is empty, it will be /etc by default. If the nfsmount.conf is absent, or the default
+// version is not overridden in the configuration file, a wrapped ErrNotConfigured error will be returned. It is possible
+// for the caller to tell if the configuration is overridden by errors.Is(err, types.ErrNotConfigured).
+func GetSystemDefaultNFSVersion(configDir string) (major, minor int, err error) {
+	if configDir == "" {
+		configDir = types.SysEtcDirectory
+	}
+
+	configMap, err := getSystemNFSMountConfigMap(configDir)
+	if os.IsNotExist(err) {
+		return 0, 0, fmt.Errorf("system default NFS version is not overridden under %q: %w", configDir, types.ErrNotConfigured)
+	} else if err != nil {
+		return 0, 0, err
+	}
+	if globalSection, ok := configMap[nfsmountGlobalSection]; ok {
+		if configured, ok := globalSection[nfsmountDefaultVersion]; ok {
+			majorStr, minorStr, _ := strings.Cut(configured, ".")
+			major, err := strconv.Atoi(majorStr)
+			if err != nil {
+				return 0, 0, errors.Wrapf(err, "invalid NFS major version %q", configured)
+			}
+
+			minor := 0
+			if minorStr != "" {
+				minor, err = strconv.Atoi(minorStr)
+				if err != nil {
+					return 0, 0, errors.Wrapf(err, "invalid NFS minor version %q", configured)
+				}
+			}
+			return major, minor, nil
+		}
+	}
+	return 0, 0, fmt.Errorf("system default NFS version is not overridden under %q: %w", configDir, types.ErrNotConfigured)
+}
+
+// getSystemNFSMountConfigMap reads the nfsmount.conf under configDir. The returned result is in
+// map[section]map[key]value structure, and the global options is result["NFSMount_Global_Options"]. Refer to man page
+// for more detail: man 5 nfsmount.conf
+func getSystemNFSMountConfigMap(configDir string) (map[string]map[string]string, error) {
+	configFilePath := filepath.Join(configDir, types.NFSMountFileName)
+	configFile, err := os.Open(configFilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer configFile.Close()
+
+	configMap := make(map[string]map[string]string)
+	scanner := bufio.NewScanner(configFile)
+	var section = ""
+	var sectionMap map[string]string
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			section = strings.TrimSpace(strings.Trim(line, "[]"))
+			continue
+		}
+		if sectionMap = configMap[section]; sectionMap == nil {
+			sectionMap = make(map[string]string)
+			configMap[section] = sectionMap
+		}
+		if key, val, isParsable := strings.Cut(line, "="); isParsable {
+			sectionMap[strings.TrimSpace(key)] = strings.TrimSpace(val)
+		} else {
+			return nil, fmt.Errorf("invalid key-value pair: '%s'", line)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return configMap, nil
+}

--- a/nfs/nfs_test.go
+++ b/nfs/nfs_test.go
@@ -1,0 +1,124 @@
+package nfs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/longhorn/go-common-libs/types"
+
+	"github.com/longhorn/go-common-libs/test"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+func (s *TestSuite) TestGetSystemDefaultNFSVersion(c *C) {
+	genNFSMountConf := func(dir string, nfsVer string) {
+		data := fmt.Sprintf("[ NFSMount_Global_Options ]\nDefaultvers=%s\n", nfsVer)
+		err := os.WriteFile(filepath.Join(dir, types.NFSMountFileName), []byte(data), 0644)
+		c.Assert(err, IsNil)
+	}
+
+	type testCase struct {
+		setup           func(dir string)
+		expectedMajor   int
+		expectedMinor   int
+		expectedMissing bool
+		expectedError   bool
+	}
+	testCases := map[string]testCase{
+		"GetSystemDefaultNFSVersion(...): system NFS mount config absent": {
+			setup: func(dir string) {
+				_, err := os.Stat(filepath.Join(dir, types.NFSMountFileName))
+				c.Assert(os.IsNotExist(err), Equals, true)
+			},
+			expectedMajor:   0,
+			expectedMinor:   0,
+			expectedMissing: true,
+			expectedError:   true,
+		},
+		"GetSystemDefaultNFSVersion(...): system NFS mount config exist without default ver": {
+			setup: func(dir string) {
+				data := "[ NFSMount_Global_Options ]\notherkey=val\n"
+				err := os.WriteFile(filepath.Join(dir, types.NFSMountFileName), []byte(data), 0644)
+				c.Assert(err, IsNil)
+			},
+			expectedMajor:   0,
+			expectedMinor:   0,
+			expectedMissing: true,
+			expectedError:   true,
+		},
+		"GetSystemDefaultNFSVersion(...): system NFS mount config set default ver to 3": {
+			setup:           func(dir string) { genNFSMountConf(dir, "3") },
+			expectedMajor:   3,
+			expectedMinor:   0,
+			expectedMissing: false,
+			expectedError:   false,
+		},
+		"GetSystemDefaultNFSVersion(...): system NFS mount config set default ver to 4": {
+			setup:           func(dir string) { genNFSMountConf(dir, "4") },
+			expectedMajor:   4,
+			expectedMinor:   0,
+			expectedMissing: false,
+			expectedError:   false,
+		},
+		"GetSystemDefaultNFSVersion(...): system NFS mount config set default ver to 4.0": {
+			setup:           func(dir string) { genNFSMountConf(dir, "4.0") },
+			expectedMajor:   4,
+			expectedMinor:   0,
+			expectedMissing: false,
+			expectedError:   false,
+		},
+		"GetSystemDefaultNFSVersion(...): system NFS mount config set default ver to 4.2": {
+			setup:           func(dir string) { genNFSMountConf(dir, "4.2") },
+			expectedMajor:   4,
+			expectedMinor:   2,
+			expectedMissing: false,
+			expectedError:   false,
+		},
+		"GetSystemDefaultNFSVersion(...): system NFS mount config default ver to invalid value": {
+			setup:           func(dir string) { genNFSMountConf(dir, "???") },
+			expectedMajor:   0,
+			expectedMinor:   0,
+			expectedMissing: false,
+			expectedError:   true,
+		},
+		"GetSystemDefaultNFSVersion(...): system NFS mount config default ver to empty value": {
+			setup:           func(dir string) { genNFSMountConf(dir, "") },
+			expectedMajor:   0,
+			expectedMinor:   0,
+			expectedMissing: false,
+			expectedError:   true,
+		},
+	}
+
+	configDir := c.MkDir()
+
+	for testName, testCase := range testCases {
+		func() {
+			c.Logf("testing utils.%v", testName)
+
+			defer os.Remove(filepath.Join(configDir, types.NFSMountFileName))
+			testCase.setup(configDir)
+
+			major, minor, err := GetSystemDefaultNFSVersion(configDir)
+			c.Assert(major, Equals, testCase.expectedMajor, Commentf(test.ErrResultFmt, testName))
+			c.Assert(minor, Equals, testCase.expectedMinor, Commentf(test.ErrResultFmt, testName))
+			if testCase.expectedMissing {
+				c.Assert(errors.Is(err, types.ErrNotConfigured), Equals, true, Commentf(test.ErrResultFmt, testName))
+			} else if testCase.expectedError {
+				c.Assert(err, NotNil, Commentf(test.ErrErrorFmt, testName))
+			} else {
+				c.Assert(err, IsNil, Commentf(test.ErrErrorFmt, testName))
+			}
+		}()
+	}
+}

--- a/types/error.go
+++ b/types/error.go
@@ -1,0 +1,23 @@
+package types
+
+import "github.com/pkg/errors"
+
+var (
+	// It is recommended to wrap the following common errors with meaningful message, so that the error handler can unwrap
+	// the underlying error and compare directly using errors.Is. For example:
+	//
+	//	func GetSysConfig(filePath string) (string, error) {
+	//		configVal, err := readConfig(filePath)
+	//		if os.IsNotExist(err) {
+	//			return fmt.Errorf("config file %q not present: %w", filePath, ErrNotConfigured)
+	//		}
+	//		...
+	//	}
+	//
+	//	configVal, err := GetSysConfig(filePath)
+	//	if errors.Is(err, types.ErrNotConfigured) {
+	//		configVal = defaultVal
+	//	}
+
+	ErrNotConfigured = errors.New("is not configured")
+)

--- a/types/nfs.go
+++ b/types/nfs.go
@@ -1,0 +1,3 @@
+package types
+
+const NFSMountFileName = "nfsmount.conf"

--- a/types/sys.go
+++ b/types/sys.go
@@ -2,6 +2,11 @@ package types
 
 const OsReleaseFilePath = "/etc/os-release"
 const SysClassBlockDirectory = "/sys/class/block/"
+const SysBootDirectory = "/boot/"
+const SysProcDirectory = "/proc/"
+const SysEtcDirectory = "/etc/"
+
+const SysKernelConfigGz = "config.gz"
 
 const OSDistroTalosLinux = "talos"
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#9830

#### What this PR does / why we need it:

We need to check NFS version information both in preflight checker and the node controller in LH manager. This PR provide the common logic for the above checks.

#### Special notes for your reviewer:

#### Additional documentation or context
