### PR TITLE
fix(cryptsetup): failed to open key file on Talos verion > 1.9

### DIFF
--- a/ns/crypto.go
+++ b/ns/crypto.go
@@ -12,7 +12,7 @@ import (
 // LuksOpen runs cryptsetup luksOpen with the given passphrase and
 // returns the stdout and error.
 func (nsexec *Executor) LuksOpen(volume, devicePath, passphrase string, timeout time.Duration) (stdout string, err error) {
-	args := []string{"luksOpen", devicePath, volume, "-d", "/dev/stdin"}
+	args := []string{"luksOpen", devicePath, volume, "-d", "-"}
 	return nsexec.CryptsetupWithPassphrase(passphrase, args, timeout)
 }
 
@@ -32,7 +32,7 @@ func (nsexec *Executor) LuksFormat(devicePath, passphrase, keyCipher, keyHash, k
 		"--hash", keyHash,
 		"--key-size", keySize,
 		"--pbkdf", pbkdf,
-		devicePath, "-d", "/dev/stdin",
+		devicePath, "-d", "-",
 	}
 	return nsexec.CryptsetupWithPassphrase(passphrase, args, timeout)
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10584

#### What this PR does / why we need it:

https://github.com/longhorn/longhorn/issues/10584#issuecomment-2734973730

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
