### PR TITLE
fix: add const type Luks2EncryptionHeaderSize

### DIFF
--- a/types/crypto.go
+++ b/types/crypto.go
@@ -13,6 +13,19 @@ const (
 	CryptoPBKDF                = "CRYPTO_PBKDF"
 	CryptoPBKDFForceIterations = "CRYPTO_PBKDF_FORCE_ITERATIONS"
 	CryptoPBKDFMemory          = "CRYPTO_PBKDF_MEMORY"
+
+	CliAPIVersionForSupportingExtendLuks2HeaderSize = 12
+	Luks2EncryptionHeaderSize                       = 16 * 1024 * 1024
 )
 
 const LuksTimeout = time.Minute
+
+func GetBackendSize(volumeSize int64, encrypted bool, cliAPIVersion int) int64 {
+	if volumeSize > 0 && encrypted && cliAPIVersion >= CliAPIVersionForSupportingExtendLuks2HeaderSize {
+		//  The default size is 16MB for the LUKS2 header, so we need to add it to the replica size if the volume is encrypted.
+		//  otherwise, the device that users get will be 16MB smaller than the actual size users want, which will cause some issues as https://github.com/longhorn/longhorn/issues/9205.
+		//  https://gitlab.com/cryptsetup/cryptsetup/-/wikis/FrequentlyAskedQuestions
+		return volumeSize + Luks2EncryptionHeaderSize
+	}
+	return volumeSize
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#9205

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
