### PR TITLE
feat(wal): add crash-safe write-ahead log package

### DIFF
--- a/.codespell-ignore-words
+++ b/.codespell-ignore-words
@@ -1,0 +1,1 @@
+AtLeast

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,20 +3,22 @@ name: Codespell
 on:
   pull_request:
     branches:
-    - master
-    - main
-    - "v*.*.*"
+      - master
+      - main
+      - "v*.*.*"
 
 jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      with:
-        fetch-depth: 1
-    - name: Check code spell
-      uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
-      with:
-        check_filenames: true
-        skip: "./proto,*/**.yaml,*/**.yml,./scripts,./vendor,MAINTAINERS,LICENSE,go.mod,go.sum"
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 1
+
+      - name: Check code spell
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
+        with:
+          check_filenames: true
+          skip: "./proto,*/**.yaml,*/**.yml,./scripts,./vendor,MAINTAINERS,LICENSE,go.mod,go.sum"
+          ignore_words_file: .codespell-ignore-words

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/avast/retry-go/v4 v4.7.0
 	github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8
 	github.com/cockroachdb/errors v1.12.0
+	github.com/gofrs/flock v0.13.0
 	github.com/google/uuid v1.6.0
 	github.com/longhorn/types v0.0.0-20260709032252-3d0a3cd8f06f
 	github.com/mitchellh/go-ps v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=

--- a/io/file.go
+++ b/io/file.go
@@ -234,6 +234,26 @@ func SyncFile(filePath string) error {
 	return file.Sync()
 }
 
+// FsyncDir fsyncs a directory so that file create / rename / unlink
+// entries within it are durable. POSIX requires this after os.Rename to
+// guarantee crash recovery sees the new name.
+func FsyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open dir %v for fsync", dir)
+	}
+	defer func() {
+		if errClose := d.Close(); errClose != nil {
+			logrus.WithError(errClose).Errorf("Failed to close dir %v", dir)
+		}
+	}()
+
+	if err := d.Sync(); err != nil {
+		return errors.Wrapf(err, "failed to fsync dir %v", dir)
+	}
+	return nil
+}
+
 // GetDiskStat returns the disk stat for the specified path.
 func GetDiskStat(path string) (diskStat types.DiskStat, err error) {
 	defer func() {

--- a/io/file_test.go
+++ b/io/file_test.go
@@ -579,6 +579,43 @@ func TestSyncFile(t *testing.T) {
 	}
 }
 
+func TestFsyncDir(t *testing.T) {
+	fakeDir := fake.CreateTempDirectory("", t)
+	defer func() {
+		_ = os.RemoveAll(fakeDir)
+	}()
+
+	type testCase struct {
+		isDirExist bool
+
+		expectError bool
+	}
+	testCases := map[string]testCase{
+		"Existing directory": {
+			isDirExist: true,
+		},
+		"Not existing directory": {
+			isDirExist:  false,
+			expectError: true,
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			dirPath := filepath.Join(fakeDir, "not-exist")
+			if testCase.isDirExist {
+				dirPath = fakeDir
+			}
+
+			err := FsyncDir(dirPath)
+			if testCase.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err, Commentf(test.ErrErrorFmt, testName, err))
+		})
+	}
+}
+
 func TestGetDiskStat(t *testing.T) {
 	fakeDir := fake.CreateTempDirectory("", t)
 	defer func() {

--- a/vendor/github.com/gofrs/flock/.gitignore
+++ b/vendor/github.com/gofrs/flock/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/gofrs/flock/.golangci.yml
+++ b/vendor/github.com/gofrs/flock/.golangci.yml
@@ -1,0 +1,116 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+
+linters:
+  enable:
+    - asasalint
+    - bidichk
+    - dogsled
+    - dupword
+    - durationcheck
+    - err113
+    - errname
+    - errorlint
+    - fatcontext
+    - forbidigo
+    - gocheckcompilerdirectives
+    - gochecknoinits
+    - gocritic
+    - godot
+    - godox
+    - goheader
+    - gomoddirectives
+    - goprintffuncname
+    - gosec
+    - inamedparam
+    - interfacebloat
+    - ireturn
+    - mirror
+    - misspell
+    - nolintlint
+    - revive
+    - staticcheck
+    - testifylint
+    - thelper
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - whitespace
+    - wsl_v5
+  settings:
+    gocritic:
+      disabled-checks:
+        - paramTypeCombine # already handle by gofumpt.extra-rules
+        - whyNoLint # already handle by nonolint
+        - unnamedResult
+        - hugeParam
+        - sloppyReassign
+        - rangeValCopy
+        - octalLiteral
+        - ptrToRefParam
+        - appendAssign
+        - ruleguard
+        - httpNoBody
+        - exposedSyncMutex
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+    godox:
+      keywords:
+        - FIXME
+    goheader:
+      template: |-
+        Copyright 2015 Tim Heckman. All rights reserved.
+        Copyright 2018-{{ YEAR }} The Gofrs. All rights reserved.
+        Use of this source code is governed by the BSD 3-Clause
+        license that can be found in the LICENSE file.
+    gosec:
+      excludes:
+        - G115
+    misspell:
+      locale: US
+    revive:
+      rules:
+        - name: struct-tag
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: if-return
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unused-parameter
+        - name: unreachable-code
+        - name: redefines-builtin-id
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - std-error-handling
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+

--- a/vendor/github.com/gofrs/flock/LICENSE
+++ b/vendor/github.com/gofrs/flock/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2018-2025, The Gofrs
+Copyright (c) 2015-2020, Tim Heckman
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of gofrs nor the names of its contributors may be used
+  to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/gofrs/flock/Makefile
+++ b/vendor/github.com/gofrs/flock/Makefile
@@ -1,0 +1,15 @@
+.PHONY: lint test test_race build_cross_os
+
+default: lint test build_cross_os
+
+test:
+	go test -v -cover ./...
+
+test_race:
+	CGO_ENABLED=1 go test -v -race ./...
+
+lint:
+	golangci-lint run
+
+build_cross_os:
+	./build.sh

--- a/vendor/github.com/gofrs/flock/README.md
+++ b/vendor/github.com/gofrs/flock/README.md
@@ -1,0 +1,45 @@
+# flock
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/gofrs/flock.svg)](https://pkg.go.dev/github.com/gofrs/flock)
+[![License](https://img.shields.io/badge/license-BSD_3--Clause-brightgreen.svg?style=flat)](https://github.com/gofrs/flock/blob/main/LICENSE)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gofrs/flock)](https://goreportcard.com/report/github.com/gofrs/flock)
+
+`flock` implements a thread-safe file lock.
+
+It also includes a non-blocking `TryLock()` function to allow locking without blocking execution.
+
+## Installation
+
+```bash
+go get -u github.com/gofrs/flock
+```
+
+## Usage
+
+```go
+import "github.com/gofrs/flock"
+
+fileLock := flock.New("/var/lock/go-lock.lock")
+
+locked, err := fileLock.TryLock()
+
+if err != nil {
+	// handle locking error
+}
+
+if locked {
+	// do work
+	fileLock.Unlock()
+}
+```
+
+For more detailed usage information take a look at the package API docs on
+[GoDoc](https://pkg.go.dev/github.com/gofrs/flock).
+
+## License
+
+`flock` is released under the BSD 3-Clause License. See the [`LICENSE`](./LICENSE) file for more details.
+
+## Project History
+
+This project was originally `github.com/theckman/go-flock`, it was transferred to Gofrs by the original author [Tim Heckman ](https://github.com/theckman).

--- a/vendor/github.com/gofrs/flock/SECURITY.md
+++ b/vendor/github.com/gofrs/flock/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+We support the latest version of this library.
+We do not guarantee support of previous versions.
+
+If a defect is reported, it will generally be fixed on the latest version (provided it exists) irrespective of whether it was introduced in a prior version.
+
+## Reporting a Vulnerability
+
+To report a potential security vulnerability, please create a [security advisory](https://github.com/gofrs/flock/security/advisories/new).
+
+For us to respond to your report most effectively, please include any of the following:
+
+- Steps to reproduce or a proof-of-concept
+- Any relevant information, including the versions used
+
+## Security Scorecard
+
+This project submits security [results](https://scorecard.dev/viewer/?uri=github.com/gofrs/flock) to the [OpenSSF Scorecard](https://securityscorecards.dev/).

--- a/vendor/github.com/gofrs/flock/build.sh
+++ b/vendor/github.com/gofrs/flock/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+# Not supported by flock:
+# - plan9/*
+# - js/wasm
+# - wasp1/wasm
+
+for row in $(go tool dist list -json | jq -r '.[] | @base64'); do
+  _jq() {
+    echo ${row} | base64 --decode | jq -r ${1}
+  }
+
+  GOOS=$(_jq '.GOOS')
+  GOARCH=$(_jq '.GOARCH')
+
+  echo "$GOOS/$GOARCH"
+  GOOS=$GOOS GOARCH=$GOARCH go build
+done

--- a/vendor/github.com/gofrs/flock/flock.go
+++ b/vendor/github.com/gofrs/flock/flock.go
@@ -1,0 +1,222 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Copyright 2018-2025 The Gofrs. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+// Package flock implements a thread-safe interface for file locking.
+// It also includes a non-blocking TryLock() function to allow locking
+// without blocking execution.
+//
+// Package flock is released under the BSD 3-Clause License. See the LICENSE file
+// for more details.
+//
+// While using this library, remember that the locking behaviors are not
+// guaranteed to be the same on each platform. For example, some UNIX-like
+// operating systems will transparently convert a shared lock to an exclusive
+// lock. If you Unlock() the flock from a location where you believe that you
+// have the shared lock, you may accidentally drop the exclusive lock.
+package flock
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+)
+
+type Option func(f *Flock)
+
+// SetFlag sets the flag used to create/open the file.
+func SetFlag(flag int) Option {
+	return func(f *Flock) {
+		f.flag = flag
+	}
+}
+
+// SetPermissions sets the OS permissions to set on the file.
+func SetPermissions(perm fs.FileMode) Option {
+	return func(f *Flock) {
+		f.perm = perm
+	}
+}
+
+// Flock is the struct type to handle file locking. All fields are unexported,
+// with access to some of the fields provided by getter methods (Path() and Locked()).
+type Flock struct {
+	path string
+	m    sync.RWMutex
+	fh   *os.File
+	l    bool
+	r    bool
+
+	// flag is the flag used to create/open the file.
+	flag int
+	// perm is the OS permissions to set on the file.
+	perm fs.FileMode
+}
+
+// New returns a new instance of *Flock. The only parameter
+// it takes is the path to the desired lockfile.
+func New(path string, opts ...Option) *Flock {
+	// create it if it doesn't exist, and open the file read-only.
+	flags := os.O_CREATE
+
+	switch runtime.GOOS {
+	case "aix", "solaris", "illumos":
+		// AIX cannot preform write-lock (i.e. exclusive) on a read-only file.
+		flags |= os.O_RDWR
+	default:
+		flags |= os.O_RDONLY
+	}
+
+	f := &Flock{
+		path: path,
+		flag: flags,
+		perm: fs.FileMode(0o600),
+	}
+
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	return f
+}
+
+// NewFlock returns a new instance of *Flock. The only parameter
+// it takes is the path to the desired lockfile.
+//
+// Deprecated: Use New instead.
+func NewFlock(path string) *Flock {
+	return New(path)
+}
+
+// Close is equivalent to calling Unlock.
+//
+// This will release the lock and close the underlying file descriptor.
+// It will not remove the file from disk, that's up to your application.
+func (f *Flock) Close() error {
+	return f.Unlock()
+}
+
+// Path returns the path as provided in NewFlock().
+func (f *Flock) Path() string {
+	return f.path
+}
+
+// Locked returns the lock state (locked: true, unlocked: false).
+//
+// Warning: by the time you use the returned value, the state may have changed.
+func (f *Flock) Locked() bool {
+	f.m.RLock()
+	defer f.m.RUnlock()
+
+	return f.l
+}
+
+// RLocked returns the read lock state (locked: true, unlocked: false).
+//
+// Warning: by the time you use the returned value, the state may have changed.
+func (f *Flock) RLocked() bool {
+	f.m.RLock()
+	defer f.m.RUnlock()
+
+	return f.r
+}
+
+// Stat returns the FileInfo structure describing the lock file.
+// If the lock file does not exist or cannot be accessed, an error is returned.
+//
+// This can be used to check the modification time of the lock file,
+// which is useful for detecting stale locks.
+func (f *Flock) Stat() (fs.FileInfo, error) {
+	f.m.RLock()
+	defer f.m.RUnlock()
+
+	if f.fh != nil {
+		return f.fh.Stat()
+	}
+
+	return os.Stat(f.path)
+}
+
+func (f *Flock) String() string {
+	return f.path
+}
+
+// TryLockContext repeatedly tries to take an exclusive lock until one of the conditions is met:
+// - TryLock succeeds
+// - TryLock fails with error
+// - Context Done channel is closed.
+func (f *Flock) TryLockContext(ctx context.Context, retryDelay time.Duration) (bool, error) {
+	return tryCtx(ctx, f.TryLock, retryDelay)
+}
+
+// TryRLockContext repeatedly tries to take a shared lock until one of the conditions is met:
+// - TryRLock succeeds
+// - TryRLock fails with error
+// - Context Done channel is closed.
+func (f *Flock) TryRLockContext(ctx context.Context, retryDelay time.Duration) (bool, error) {
+	return tryCtx(ctx, f.TryRLock, retryDelay)
+}
+
+func tryCtx(ctx context.Context, fn func() (bool, error), retryDelay time.Duration) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+
+	for {
+		if ok, err := fn(); ok || err != nil {
+			return ok, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(retryDelay):
+		}
+	}
+}
+
+func (f *Flock) setFh(flag int) error {
+	// open a new os.File instance
+	fh, err := os.OpenFile(f.path, flag, f.perm)
+	if err != nil {
+		return err
+	}
+
+	// set the file handle on the struct
+	f.fh = fh
+
+	return nil
+}
+
+// resetFh resets file handle:
+// - tries to close the file (ignore errors)
+// - sets fh to nil.
+func (f *Flock) resetFh() {
+	if f.fh == nil {
+		return
+	}
+
+	_ = f.fh.Close()
+
+	f.fh = nil
+}
+
+// ensure the file handle is closed if no lock is held.
+func (f *Flock) ensureFhState() {
+	if f.l || f.r || f.fh == nil {
+		return
+	}
+
+	f.resetFh()
+}
+
+func (f *Flock) reset() {
+	f.l = false
+	f.r = false
+
+	f.resetFh()
+}

--- a/vendor/github.com/gofrs/flock/flock_others.go
+++ b/vendor/github.com/gofrs/flock/flock_others.go
@@ -1,0 +1,45 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Copyright 2018-2025 The Gofrs. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+//go:build (!unix && !windows) || plan9
+
+package flock
+
+import (
+	"errors"
+	"io/fs"
+)
+
+func (f *Flock) Lock() error {
+	return &fs.PathError{
+		Op:   "Lock",
+		Path: f.Path(),
+		Err:  errors.ErrUnsupported,
+	}
+}
+
+func (f *Flock) RLock() error {
+	return &fs.PathError{
+		Op:   "RLock",
+		Path: f.Path(),
+		Err:  errors.ErrUnsupported,
+	}
+}
+
+func (f *Flock) Unlock() error {
+	return &fs.PathError{
+		Op:   "Unlock",
+		Path: f.Path(),
+		Err:  errors.ErrUnsupported,
+	}
+}
+
+func (f *Flock) TryLock() (bool, error) {
+	return false, f.Lock()
+}
+
+func (f *Flock) TryRLock() (bool, error) {
+	return false, f.RLock()
+}

--- a/vendor/github.com/gofrs/flock/flock_unix.go
+++ b/vendor/github.com/gofrs/flock/flock_unix.go
@@ -1,0 +1,211 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Copyright 2018-2025 The Gofrs. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+//go:build darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd
+
+package flock
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// Lock is a blocking call to try and take an exclusive file lock.
+// It will wait until it is able to obtain the exclusive file lock.
+// It's recommended that TryLock() be used over this function.
+// This function may block the ability to query the current Locked() or RLocked() status due to a RW-mutex lock.
+//
+// If we are already exclusive-locked,
+// this function short-circuits and returns immediately assuming it can take the mutex lock.
+//
+// If the *Flock has a shared lock (RLock),
+// this may transparently replace the shared lock with an exclusive lock on some UNIX-like operating systems.
+// Be careful when using exclusive locks in conjunction with shared locks (RLock()),
+// because calling Unlock() may accidentally release the exclusive lock that was once a shared lock.
+func (f *Flock) Lock() error {
+	return f.lock(&f.l, unix.LOCK_EX)
+}
+
+// RLock is a blocking call to try and take a shared file lock.
+// It will wait until it is able to obtain the shared file lock.
+// It's recommended that TryRLock() be used over this function.
+// This function may block the ability to query the current Locked() or RLocked() status due to a RW-mutex lock.
+//
+// If we are already shared-locked,
+// this function short-circuits and returns immediately assuming it can take the mutex lock.
+func (f *Flock) RLock() error {
+	return f.lock(&f.r, unix.LOCK_SH)
+}
+
+func (f *Flock) lock(locked *bool, flag int) error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if *locked {
+		return nil
+	}
+
+	if f.fh == nil {
+		if err := f.setFh(f.flag); err != nil {
+			return err
+		}
+
+		defer f.ensureFhState()
+	}
+
+	err := unix.Flock(int(f.fh.Fd()), flag)
+	if err != nil {
+		shouldRetry, reopenErr := f.reopenFDOnError(err)
+		if reopenErr != nil {
+			return reopenErr
+		}
+
+		if !shouldRetry {
+			return err
+		}
+
+		err = unix.Flock(int(f.fh.Fd()), flag)
+		if err != nil {
+			return err
+		}
+	}
+
+	*locked = true
+
+	return nil
+}
+
+// Unlock is a function to unlock the file.
+// This file takes a RW-mutex lock,
+// so while it is running the Locked() and RLocked() functions will be blocked.
+//
+// This function short-circuits if we are unlocked already.
+// If not, it calls unix.LOCK_UN on the file and closes the file descriptor.
+// It does not remove the file from disk. It's up to your application to do.
+//
+// Please note,
+// if your shared lock became an exclusive lock,
+// this may unintentionally drop the exclusive lock if called by the consumer that believes they have a shared lock.
+// Please see Lock() for more details.
+func (f *Flock) Unlock() error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	// If we aren't locked or if the lockfile instance is nil
+	// just return a nil error because we are unlocked.
+	if (!f.l && !f.r) || f.fh == nil {
+		return nil
+	}
+
+	// Mark the file as unlocked.
+	err := unix.Flock(int(f.fh.Fd()), unix.LOCK_UN)
+	if err != nil {
+		return err
+	}
+
+	f.reset()
+
+	return nil
+}
+
+// TryLock is the preferred function for taking an exclusive file lock.
+// This function takes an RW-mutex lock before it tries to lock the file,
+// so there is the possibility that this function may block for a short time
+// if another goroutine is trying to take any action.
+//
+// The actual file lock is non-blocking.
+// If we are unable to get the exclusive file lock,
+// the function will return false instead of waiting for the lock.
+// If we get the lock, we also set the *Flock instance as being exclusive-locked.
+func (f *Flock) TryLock() (bool, error) {
+	return f.try(&f.l, unix.LOCK_EX)
+}
+
+// TryRLock is the preferred function for taking a shared file lock.
+// This function takes an RW-mutex lock before it tries to lock the file,
+// so there is the possibility that this function may block for a short time
+// if another goroutine is trying to take any action.
+//
+// The actual file lock is non-blocking.
+// If we are unable to get the shared file lock,
+// the function will return false instead of waiting for the lock.
+// If we get the lock, we also set the *Flock instance as being share-locked.
+func (f *Flock) TryRLock() (bool, error) {
+	return f.try(&f.r, unix.LOCK_SH)
+}
+
+func (f *Flock) try(locked *bool, flag int) (bool, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if *locked {
+		return true, nil
+	}
+
+	if f.fh == nil {
+		if err := f.setFh(f.flag); err != nil {
+			return false, err
+		}
+
+		defer f.ensureFhState()
+	}
+
+	var retried bool
+
+retry:
+	err := unix.Flock(int(f.fh.Fd()), flag|unix.LOCK_NB)
+
+	switch {
+	case errors.Is(err, unix.EWOULDBLOCK):
+		return false, nil
+	case err == nil:
+		*locked = true
+		return true, nil
+	}
+
+	if !retried {
+		shouldRetry, reopenErr := f.reopenFDOnError(err)
+		if reopenErr != nil {
+			return false, reopenErr
+		} else if shouldRetry {
+			retried = true
+			goto retry
+		}
+	}
+
+	return false, err
+}
+
+// reopenFDOnError determines whether we should reopen the file handle in readwrite mode and try again.
+// This comes from `util-linux/sys-utils/flock.c`:
+// > Since Linux 3.4 (commit 55725513)
+// > Probably NFSv4 where flock() is emulated by fcntl().
+// > https://github.com/util-linux/util-linux/blob/198e920aa24743ef6ace4e07cf6237de527f9261/sys-utils/flock.c#L374-L390
+func (f *Flock) reopenFDOnError(err error) (bool, error) {
+	if !errors.Is(err, unix.EIO) && !errors.Is(err, unix.EBADF) {
+		return false, nil
+	}
+
+	st, err := f.fh.Stat()
+	if err != nil {
+		return false, nil
+	}
+
+	if st.Mode()&f.perm != f.perm {
+		return false, nil
+	}
+
+	f.resetFh()
+
+	// reopen in read-write mode and set the file handle
+	err = f.setFh(f.flag | os.O_RDWR)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/vendor/github.com/gofrs/flock/flock_unix_fcntl.go
+++ b/vendor/github.com/gofrs/flock/flock_unix_fcntl.go
@@ -1,0 +1,393 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Copyright 2018-2025 The Gofrs. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This code implements the filelock API using POSIX 'fcntl' locks,
+// which attach to an (inode, process) pair rather than a file descriptor.
+// To avoid unlocking files prematurely when the same file is opened through different descriptors,
+// we allow only one read-lock at a time.
+//
+// This code is adapted from the Go package (go.22):
+// https://github.com/golang/go/blob/release-branch.go1.22/src/cmd/go/internal/lockedfile/internal/filelock/filelock_fcntl.go
+
+//go:build aix || (solaris && !illumos)
+
+package flock
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"math/rand"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// https://github.com/golang/go/blob/09aeb6e33ab426eff4676a3baf694d5a3019e9fc/src/cmd/go/internal/lockedfile/internal/filelock/filelock_fcntl.go#L28
+type lockType int16
+
+// String returns the name of the function corresponding to lt
+// (Lock, RLock, or Unlock).
+// https://github.com/golang/go/blob/09aeb6e33ab426eff4676a3baf694d5a3019e9fc/src/cmd/go/internal/lockedfile/internal/filelock/filelock.go#L67
+func (lt lockType) String() string {
+	switch lt {
+	case readLock:
+		return "RLock"
+	case writeLock:
+		return "Lock"
+	default:
+		return "Unlock"
+	}
+}
+
+// https://github.com/golang/go/blob/09aeb6e33ab426eff4676a3baf694d5a3019e9fc/src/cmd/go/internal/lockedfile/internal/filelock/filelock_fcntl.go#L30-L33
+const (
+	readLock  lockType = unix.F_RDLCK
+	writeLock lockType = unix.F_WRLCK
+)
+
+// https://github.com/golang/go/blob/09aeb6e33ab426eff4676a3baf694d5a3019e9fc/src/cmd/go/internal/lockedfile/internal/filelock/filelock_fcntl.go#L35
+type inode = uint64
+
+// https://github.com/golang/go/blob/09aeb6e33ab426eff4676a3baf694d5a3019e9fc/src/cmd/go/internal/lockedfile/internal/filelock/filelock_fcntl.go#L37-L40
+type inodeLock struct {
+	owner *Flock
+	queue []<-chan *Flock
+}
+
+type cmdType int
+
+const (
+	tryLock  cmdType = unix.F_SETLK
+	waitLock cmdType = unix.F_SETLKW
+)
+
+var (
+	mu     sync.Mutex
+	inodes = map[*Flock]inode{}
+	locks  = map[inode]inodeLock{}
+)
+
+// Lock is a blocking call to try and take an exclusive file lock.
+// It will wait until it is able to obtain the exclusive file lock.
+// It's recommended that TryLock() be used over this function.
+// This function may block the ability to query the current Locked() or RLocked() status due to a RW-mutex lock.
+//
+// If we are already exclusive-locked, this function short-circuits and
+// returns immediately assuming it can take the mutex lock.
+//
+// If the *Flock has a shared lock (RLock),
+// this may transparently replace the shared lock with an exclusive lock on some UNIX-like operating systems.
+// Be careful when using exclusive locks in conjunction with shared locks (RLock()),
+// because calling Unlock() may accidentally release the exclusive lock that was once a shared lock.
+func (f *Flock) Lock() error {
+	return f.lock(&f.l, writeLock)
+}
+
+// RLock is a blocking call to try and take a shared file lock.
+// It will wait until it is able to obtain the shared file lock.
+// It's recommended that TryRLock() be used over this function.
+// This function may block the ability to query the current Locked() or RLocked() status due to a RW-mutex lock.
+//
+// If we are already shared-locked, this function short-circuits and
+// returns immediately assuming it can take the mutex lock.
+func (f *Flock) RLock() error {
+	return f.lock(&f.r, readLock)
+}
+
+func (f *Flock) lock(locked *bool, flag lockType) error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if *locked {
+		return nil
+	}
+
+	if f.fh == nil {
+		if err := f.setFh(f.flag); err != nil {
+			return err
+		}
+
+		defer f.ensureFhState()
+	}
+
+	_, err := f.doLock(waitLock, flag, true)
+	if err != nil {
+		return err
+	}
+
+	*locked = true
+
+	return nil
+}
+
+// https://github.com/golang/go/blob/09aeb6e33ab426eff4676a3baf694d5a3019e9fc/src/cmd/go/internal/lockedfile/internal/filelock/filelock_fcntl.go#L48
+func (f *Flock) doLock(cmd cmdType, lt lockType, blocking bool) (bool, error) {
+	// POSIX locks apply per inode and process,
+	// and the lock for an inode is released when *any* descriptor for that inode is closed.
+	// So we need to synchronize access to each inode internally,
+	// and must serialize lock and unlock calls that refer to the same inode through different descriptors.
+	fi, err := f.fh.Stat()
+	if err != nil {
+		return false, err
+	}
+
+	// Note(ldez): don't replace `syscall.Stat_t` by `unix.Stat_t` because `FileInfo.Sys()` returns `syscall.Stat_t`
+	ino := fi.Sys().(*syscall.Stat_t).Ino
+
+	mu.Lock()
+
+	if i, dup := inodes[f]; dup && i != ino {
+		mu.Unlock()
+		return false, &fs.PathError{
+			Op:   lt.String(),
+			Path: f.Path(),
+			Err:  errors.New("inode for file changed since last Lock or RLock"),
+		}
+	}
+
+	inodes[f] = ino
+
+	var wait chan *Flock
+
+	l := locks[ino]
+
+	switch {
+	case l.owner == f:
+		// This file already owns the lock, but the call may change its lock type.
+	case l.owner == nil:
+		// No owner: it's ours now.
+		l.owner = f
+
+	case !blocking:
+		// Already owned: cannot take the lock.
+		mu.Unlock()
+		return false, nil
+
+	default:
+		// Already owned: add a channel to wait on.
+		wait = make(chan *Flock)
+		l.queue = append(l.queue, wait)
+	}
+
+	locks[ino] = l
+
+	mu.Unlock()
+
+	if wait != nil {
+		wait <- f
+	}
+
+	// Spurious EDEADLK errors arise on platforms that compute deadlock graphs at
+	// the process, rather than thread, level. Consider processes P and Q, with
+	// threads P.1, P.2, and Q.3. The following trace is NOT a deadlock, but will be
+	// reported as a deadlock on systems that consider only process granularity:
+	//
+	// 	P.1 locks file A.
+	// 	Q.3 locks file B.
+	// 	Q.3 blocks on file A.
+	// 	P.2 blocks on file B. (This is erroneously reported as a deadlock.)
+	// 	P.1 unlocks file A.
+	// 	Q.3 unblocks and locks file A.
+	// 	Q.3 unlocks files A and B.
+	// 	P.2 unblocks and locks file B.
+	// 	P.2 unlocks file B.
+	//
+	// These spurious errors were observed in practice on AIX and Solaris in
+	// cmd/go: see https://golang.org/issue/32817.
+	//
+	// We work around this bug by treating EDEADLK as always spurious. If there
+	// really is a lock-ordering bug between the interacting processes, it will
+	// become a livelock instead, but that's not appreciably worse than if we had
+	// a proper flock implementation (which generally does not even attempt to
+	// diagnose deadlocks).
+	//
+	// In the above example, that changes the trace to:
+	//
+	// 	P.1 locks file A.
+	// 	Q.3 locks file B.
+	// 	Q.3 blocks on file A.
+	// 	P.2 spuriously fails to lock file B and goes to sleep.
+	// 	P.1 unlocks file A.
+	// 	Q.3 unblocks and locks file A.
+	// 	Q.3 unlocks files A and B.
+	// 	P.2 wakes up and locks file B.
+	// 	P.2 unlocks file B.
+	//
+	// We know that the retry loop will not introduce a *spurious* livelock
+	// because, according to the POSIX specification, EDEADLK is only to be
+	// returned when “the lock is blocked by a lock from another process”.
+	// If that process is blocked on some lock that we are holding, then the
+	// resulting livelock is due to a real deadlock (and would manifest as such
+	// when using, for example, the flock implementation of this package).
+	// If the other process is *not* blocked on some other lock that we are
+	// holding, then it will eventually release the requested lock.
+
+	nextSleep := 1 * time.Millisecond
+	const maxSleep = 500 * time.Millisecond
+	for {
+		err = setlkw(f.fh.Fd(), cmd, lt)
+		if !errors.Is(err, unix.EDEADLK) {
+			break
+		}
+
+		time.Sleep(nextSleep)
+
+		nextSleep += nextSleep
+		if nextSleep > maxSleep {
+			nextSleep = maxSleep
+		}
+		// Apply 10% jitter to avoid synchronizing collisions when we finally unblock.
+		nextSleep += time.Duration((0.1*rand.Float64() - 0.05) * float64(nextSleep))
+	}
+
+	if err != nil {
+		f.doUnlock()
+
+		if cmd == tryLock && errors.Is(err, unix.EACCES) {
+			return false, nil
+		}
+
+		return false, &fs.PathError{
+			Op:   lt.String(),
+			Path: f.Path(),
+			Err:  err,
+		}
+	}
+
+	return true, nil
+}
+
+func (f *Flock) Unlock() error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	// If we aren't locked or if the lockfile instance is nil
+	// just return a nil error because we are unlocked.
+	if (!f.l && !f.r) || f.fh == nil {
+		return nil
+	}
+
+	if err := f.doUnlock(); err != nil {
+		return err
+	}
+
+	f.reset()
+
+	return nil
+}
+
+// https://github.com/golang/go/blob/09aeb6e33ab426eff4676a3baf694d5a3019e9fc/src/cmd/go/internal/lockedfile/internal/filelock/filelock_fcntl.go#L163
+func (f *Flock) doUnlock() (err error) {
+	var owner *Flock
+
+	mu.Lock()
+
+	ino, ok := inodes[f]
+	if ok {
+		owner = locks[ino].owner
+	}
+
+	mu.Unlock()
+
+	if owner == f {
+		err = setlkw(f.fh.Fd(), waitLock, unix.F_UNLCK)
+	}
+
+	mu.Lock()
+
+	l := locks[ino]
+
+	if len(l.queue) == 0 {
+		// No waiters: remove the map entry.
+		delete(locks, ino)
+	} else {
+		// The first waiter is sending us their file now.
+		// Receive it and update the queue.
+		l.owner = <-l.queue[0]
+		l.queue = l.queue[1:]
+		locks[ino] = l
+	}
+
+	delete(inodes, f)
+
+	mu.Unlock()
+
+	return err
+}
+
+// TryLock is the preferred function for taking an exclusive file lock.
+// This function takes an RW-mutex lock before it tries to lock the file,
+// so there is the possibility that this function may block for a short time
+// if another goroutine is trying to take any action.
+//
+// The actual file lock is non-blocking.
+// If we are unable to get the exclusive file lock,
+// the function will return false instead of waiting for the lock.
+// If we get the lock, we also set the *Flock instance as being exclusive-locked.
+func (f *Flock) TryLock() (bool, error) {
+	return f.try(&f.l, writeLock)
+}
+
+// TryRLock is the preferred function for taking a shared file lock.
+// This function takes an RW-mutex lock before it tries to lock the file,
+// so there is the possibility that this function may block for a short time
+// if another goroutine is trying to take any action.
+//
+// The actual file lock is non-blocking.
+// If we are unable to get the shared file lock,
+// the function will return false instead of waiting for the lock.
+// If we get the lock, we also set the *Flock instance as being share-locked.
+func (f *Flock) TryRLock() (bool, error) {
+	return f.try(&f.r, readLock)
+}
+
+func (f *Flock) try(locked *bool, flag lockType) (bool, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if *locked {
+		return true, nil
+	}
+
+	if f.fh == nil {
+		if err := f.setFh(f.flag); err != nil {
+			return false, err
+		}
+
+		defer f.ensureFhState()
+	}
+
+	hasLock, err := f.doLock(tryLock, flag, false)
+	if err != nil {
+		return false, err
+	}
+
+	*locked = hasLock
+
+	return hasLock, nil
+}
+
+// setlkw calls FcntlFlock with cmd for the entire file indicated by fd.
+// https://github.com/golang/go/blob/09aeb6e33ab426eff4676a3baf694d5a3019e9fc/src/cmd/go/internal/lockedfile/internal/filelock/filelock_fcntl.go#L198
+func setlkw(fd uintptr, cmd cmdType, lt lockType) error {
+	for {
+		err := unix.FcntlFlock(fd, int(cmd), &unix.Flock_t{
+			Type:   int16(lt),
+			Whence: io.SeekStart,
+			Start:  0,
+			Len:    0, // All bytes.
+		})
+		if !errors.Is(err, unix.EINTR) {
+			return err
+		}
+	}
+}

--- a/vendor/github.com/gofrs/flock/flock_windows.go
+++ b/vendor/github.com/gofrs/flock/flock_windows.go
@@ -1,0 +1,160 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Copyright 2018-2025 The Gofrs. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+//go:build windows
+
+package flock
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// Use of 0x00000000 for the shared lock is a guess based on some the MS Windows `LockFileEX` docs,
+// which document the `LOCKFILE_EXCLUSIVE_LOCK` flag as:
+//
+// > The function requests an exclusive lock. Otherwise, it requests a shared lock.
+//
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
+const winLockfileSharedLock = 0x00000000
+
+// ErrorLockViolation is the error code returned from the Windows syscall when a lock would block,
+// and you ask to fail immediately.
+//
+//nolint:errname // It should be renamed to `ErrLockViolation`.
+const ErrorLockViolation windows.Errno = 0x21 // 33
+
+// Lock is a blocking call to try and take an exclusive file lock.
+// It will wait until it is able to obtain the exclusive file lock.
+// It's recommended that TryLock() be used over this function.
+// This function may block the ability to query the current Locked() or RLocked() status due to a RW-mutex lock.
+//
+// If we are already locked, this function short-circuits and
+// returns immediately assuming it can take the mutex lock.
+func (f *Flock) Lock() error {
+	return f.lock(&f.l, windows.LOCKFILE_EXCLUSIVE_LOCK)
+}
+
+// RLock is a blocking call to try and take a shared file lock.
+// It will wait until it is able to obtain the shared file lock.
+// It's recommended that TryRLock() be used over this function.
+// This function may block the ability to query the current Locked() or RLocked() status due to a RW-mutex lock.
+//
+// If we are already locked, this function short-circuits and
+// returns immediately assuming it can take the mutex lock.
+func (f *Flock) RLock() error {
+	return f.lock(&f.r, winLockfileSharedLock)
+}
+
+func (f *Flock) lock(locked *bool, flag uint32) error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if *locked {
+		return nil
+	}
+
+	if f.fh == nil {
+		if err := f.setFh(f.flag); err != nil {
+			return err
+		}
+
+		defer f.ensureFhState()
+	}
+
+	err := windows.LockFileEx(windows.Handle(f.fh.Fd()), flag, 0, 1, 0, &windows.Overlapped{})
+	if err != nil && !errors.Is(err, windows.Errno(0)) {
+		return err
+	}
+
+	*locked = true
+
+	return nil
+}
+
+// Unlock is a function to unlock the file.
+// This file takes a RW-mutex lock,
+// so while it is running the Locked() and RLocked() functions will be blocked.
+//
+// This function short-circuits if we are unlocked already.
+// If not, it calls UnlockFileEx() on the file and closes the file descriptor.
+// It does not remove the file from disk.
+// It's up to your application to do.
+func (f *Flock) Unlock() error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	// if we aren't locked or if the lockfile instance is nil
+	// just return a nil error because we are unlocked
+	if (!f.l && !f.r) || f.fh == nil {
+		return nil
+	}
+
+	// mark the file as unlocked
+	err := windows.UnlockFileEx(windows.Handle(f.fh.Fd()), 0, 1, 0, &windows.Overlapped{})
+	if err != nil && !errors.Is(err, windows.Errno(0)) {
+		return err
+	}
+
+	f.reset()
+
+	return nil
+}
+
+// TryLock is the preferred function for taking an exclusive file lock.
+// This function does take a RW-mutex lock before it tries to lock the file,
+// so there is the possibility that this function may block for a short time
+// if another goroutine is trying to take any action.
+//
+// The actual file lock is non-blocking.
+// If we are unable to get the exclusive file lock,
+// the function will return false instead of waiting for the lock.
+// If we get the lock, we also set the *Flock instance as being exclusive-locked.
+func (f *Flock) TryLock() (bool, error) {
+	return f.try(&f.l, windows.LOCKFILE_EXCLUSIVE_LOCK)
+}
+
+// TryRLock is the preferred function for taking a shared file lock.
+// This function does take a RW-mutex lock before it tries to lock the file,
+// so there is the possibility that this function may block for a short time if another goroutine is trying to take any action.
+//
+// The actual file lock is non-blocking.
+// If we are unable to get the shared file lock,
+// the function will return false instead of waiting for the lock.
+// If we get the lock, we also set the *Flock instance as being shared-locked.
+func (f *Flock) TryRLock() (bool, error) {
+	return f.try(&f.r, winLockfileSharedLock)
+}
+
+func (f *Flock) try(locked *bool, flag uint32) (bool, error) {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if *locked {
+		return true, nil
+	}
+
+	if f.fh == nil {
+		if err := f.setFh(f.flag); err != nil {
+			return false, err
+		}
+
+		defer f.ensureFhState()
+	}
+
+	err := windows.LockFileEx(windows.Handle(f.fh.Fd()), flag|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &windows.Overlapped{})
+	if err != nil && !errors.Is(err, windows.Errno(0)) {
+		if errors.Is(err, ErrorLockViolation) || errors.Is(err, windows.ERROR_IO_PENDING) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	*locked = true
+
+	return true, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -81,6 +81,9 @@ github.com/go-openapi/jsonreference/internal
 # github.com/go-openapi/swag v0.23.0
 ## explicit; go 1.20
 github.com/go-openapi/swag
+# github.com/gofrs/flock v0.13.0
+## explicit; go 1.24.0
+github.com/gofrs/flock
 # github.com/gogo/protobuf v1.3.2
 ## explicit; go 1.15
 github.com/gogo/protobuf/gogoproto

--- a/wal/example_test.go
+++ b/wal/example_test.go
@@ -1,0 +1,160 @@
+package wal_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/longhorn/go-common-libs/wal"
+)
+
+// Example_writeTransaction shows the normal write path: open, recover
+// once, then record a transaction as intents -> prepare -> apply+done ->
+// commit. The apply of each step is the caller's own idempotent work and
+// is omitted here.
+func Example_writeTransaction() {
+	dir, err := os.MkdirTemp("", "wal-example")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	j, err := wal.Open(dir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Recover once after Open and before any Begin so freshly-issued
+	// TxnIDs cannot collide with transactions already durable on disk.
+	if _, err := j.Recover(); err != nil {
+		log.Fatal(err)
+	}
+
+	params, _ := json.Marshal(map[string]string{"snapshot": "snap-001"})
+	tx, err := j.Begin(wal.OpSnapCreate, params)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// 1) Write every step's intent first (nothing applied yet).
+	if err := tx.Intent(1, wal.ActionCreateHead, nil); err != nil {
+		log.Fatal(err)
+	}
+	if err := tx.Intent(2, wal.ActionUpdateVolumeMeta, nil); err != nil {
+		log.Fatal(err)
+	}
+
+	// 2) Seal the intent set. Only after Prepare is the transaction
+	//    eligible to be redone by recovery.
+	if err := tx.Prepare(); err != nil {
+		log.Fatal(err)
+	}
+
+	// 3) Apply each step (caller's own idempotent work), then mark it done.
+	//    applyCreateHead() ...
+	if err := tx.StepDone(1); err != nil {
+		log.Fatal(err)
+	}
+	//    applyUpdateVolumeMeta() ...
+	if err := tx.StepDone(2); err != nil {
+		log.Fatal(err)
+	}
+
+	// Inspect the on-disk records before committing (a clean Close below
+	// checkpoints and truncates the file to zero).
+	recs, err := j.Scan()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("records before commit: %d\n", len(recs))
+
+	if err := tx.Commit(); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("transaction committed")
+
+	if err := j.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// records before commit: 6
+	// transaction committed
+}
+
+// Example_recoverAfterCrash shows the recovery path: a process crashes
+// after Prepare and one applied step; the next process reopens, recovers
+// the pending transaction, replays only the steps that were not yet
+// durably done, and commits.
+func Example_recoverAfterCrash() {
+	dir, err := os.MkdirTemp("", "wal-example")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	// --- First process: prepare, apply step 1, then crash (SIGKILL). ---
+	j1, err := wal.Open(dir)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tx, err := j1.Begin(wal.OpSnapCreate, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = tx.Intent(1, wal.ActionCreateHead, nil)
+	_ = tx.Intent(2, wal.ActionUpdateVolumeMeta, nil)
+	_ = tx.Prepare()
+	_ = tx.StepDone(1) // step 1 applied + durable; step 2 not yet
+	// ForceCloseForTest drops the fd + flock without a clean checkpoint,
+	// simulating an abrupt process death.
+	_ = wal.ForceCloseForTest(j1)
+
+	// --- Second process: reopen and recover. ---
+	j2, err := wal.Open(dir)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() { _ = j2.Close() }()
+
+	analysis, err := j2.Recover()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("pending txns: %d\n", len(analysis.Pending))
+
+	for _, pt := range analysis.Pending {
+		adopted, err := wal.AdoptTxn(j2, pt.ID, pt.Op)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if !pt.Prepared {
+			// Intent set may be torn; abort instead of replaying.
+			_ = adopted.Abort()
+			fmt.Printf("txn %d aborted (not prepared)\n", pt.ID)
+			continue
+		}
+
+		for _, in := range pt.PendingIntents {
+			if pt.CompletedSteps[in.StepID] {
+				continue // already durably applied before the crash
+			}
+			// replay(in) idempotently ...
+			if err := adopted.StepDone(in.StepID); err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("txn %d replayed step %d (%s)\n", pt.ID, in.StepID, in.Action)
+		}
+		if err := adopted.Commit(); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("txn %d committed\n", pt.ID)
+	}
+
+	// Output:
+	// pending txns: 1
+	// txn 1 replayed step 2 (UPDATE_VOLUME_META)
+	// txn 1 committed
+}

--- a/wal/fdatasync_linux.go
+++ b/wal/fdatasync_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package wal
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// dataSync flushes the file's data and the metadata required to read it
+// back (e.g. an extended size) using fdatasync(2). It is cheaper than a
+// full fsync because it skips unrelated inode metadata (mtime/atime)
+// that the WAL does not depend on.
+func dataSync(f *os.File) error {
+	return unix.Fdatasync(int(f.Fd()))
+}

--- a/wal/fdatasync_other.go
+++ b/wal/fdatasync_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package wal
+
+import "os"
+
+// dataSync falls back to a full fsync on platforms that do not expose
+// fdatasync(2).
+func dataSync(f *os.File) error {
+	return f.Sync()
+}

--- a/wal/journal.go
+++ b/wal/journal.go
@@ -1,0 +1,1158 @@
+// Package wal implements a crash-safe append-only write-ahead log for
+// operations on a target directory.
+//
+// On-disk layout:
+//
+//	+--------+--------+--------+------------+-----------+------------+----------+
+//	| Magic  | Ver    | Type   | PayloadLen | HeaderCRC | PayloadCRC | Payload  |
+//	| 4 B    | 2 B    | 2 B    | 4 B        | 4 B       | 4 B        | N B      |
+//	+--------+--------+--------+------------+-----------+------------+----------+
+//
+// All integers are little-endian. Each record carries two independent
+// CRC32C (Castagnoli) sums: HeaderCRC covers the framing bytes
+// (Magic..PayloadLen) and PayloadCRC covers the payload. A torn tail at
+// the end of the file (partial header / partial payload) is detected and
+// silently truncated on Open: only fully-synced records are observed by
+// recovery. Mid-stream corruption (bad magic / version / CRC / oversize
+// payload) is treated as a fatal error so OpenWithQuarantine can rename
+// the file aside for offline inspection instead of silently dropping
+// durable records.
+//
+// Torn-tail vs. corruption boundary: a crash mid-append leaves a short
+// (partial) final record, detected as a torn tail (a short read of the
+// header or payload) and truncated. The separate HeaderCRC lets recovery
+// validate PayloadLen BEFORE reading the payload, so a bit flip in an
+// earlier record's length is caught as mid-stream corruption (a
+// full-length header that fails its CRC) instead of being mistaken for a
+// torn tail — which would otherwise consume the following valid records
+// and truncate them away. Only a genuinely short trailing read is treated
+// as torn; any full-length record that fails a CRC is quarantined, so the
+// WAL never silently drops a record it cannot prove is torn.
+//
+// Concurrency model: a Journal owns the data file and an advisory flock
+// on a dedicated lock file (LockFileName) for the lifetime of an open
+// Journal. A separate lock file is required because Unix rename is not
+// blocked by an advisory flock on the renamed file; using one
+// guarantees OpenWithQuarantine's data-file rename is exclusive against
+// concurrent quarantine attempts in other processes. All write methods
+// serialize through an internal mutex; the caller's own top-level lock
+// typically already serializes operations, so this mutex is just
+// defensive.
+package wal
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/gofrs/flock"
+)
+
+// FileName is the journal data file name inside the target directory.
+const FileName = "journal.log"
+
+// LockFileName is the dedicated lock file used for cross-process
+// exclusion. It is held with flock for the lifetime of an open
+// Journal. A dedicated file (separate from the data file) is required
+// so OpenWithQuarantine can safely rename the data file away without
+// dropping the lock — Unix rename is not blocked by an advisory
+// flock, so locking the data file directly would allow two concurrent
+// callers to produce a split-brain journal.
+const LockFileName = "journal.lock"
+
+const (
+	magic   uint32 = 0x4C484A4C // "LHJL" (Longhorn Journal)
+	version uint16 = 2
+
+	headerSize = 4 + 2 + 2 + 4 + 4 + 4 // 20 bytes
+
+	// MaxPayloadSize bounds a single record. Real records are tiny (<1 KB);
+	// the cap is defensive against corruption that yields huge lengths.
+	MaxPayloadSize = 1 << 20 // 1 MiB
+)
+
+var crcTable = crc32.MakeTable(crc32.Castagnoli)
+
+// ErrJournalLocked is returned by Open if another process holds the flock.
+var ErrJournalLocked = errors.New("journal is locked by another process")
+
+// ErrJournalPoisoned marks a journal that refused an append because a
+// prior append failed AND its rollback also failed, potentially leaving
+// a CRC-valid record on disk that the next Open would accept as complete
+// (torn-tail handling cannot remove a fully-framed record). Once
+// poisoned, every further append is refused so a caller retry cannot
+// create a duplicate/ghost operation; the journal must be reopened or
+// quarantined to clear the condition.
+var ErrJournalPoisoned = errors.New("journal is poisoned")
+
+// errFlockAcquire marks an Open failure caused by an underlying flock
+// acquisition error (e.g. the filesystem does not support advisory
+// locking, or the lock file cannot be created because the parent
+// directory is missing). Such errors are not caused by a corrupt
+// journal, so OpenWithQuarantine treats them like ErrJournalLocked
+// and refuses to rename the data file aside.
+var errFlockAcquire = errors.New("journal flock acquire failed")
+
+// errTornTail marks a structural read failure that is consistent with a
+// crash mid-write at the very end of the file (short read while reading
+// a header or a payload). These are safely truncatable on Open.
+// Anything else (bad magic, unsupported version, bad CRC, oversize
+// payload) is treated as mid-stream corruption: Open refuses to touch
+// the file so OpenWithQuarantine can rename it aside for inspection.
+var errTornTail = errors.New("journal torn tail")
+
+// errJournalCorrupt marks a failure that means the on-disk journal file
+// itself is unreadable as a WAL: mid-stream structural corruption (bad
+// magic / version / CRC / oversize payload), or the journal path being
+// occupied by a non-regular file. Only these justify OpenWithQuarantine
+// renaming the file aside. Transient infrastructure failures (EMFILE,
+// EIO, ENOSPC, a missing parent directory, an fsync error) are left
+// unmarked so a healthy journal is never quarantined for an environmental
+// hiccup. Semantic broken-writer errors are not surfaced by Open at all;
+// they come from Recover/Analyze and are handled by Quarantine.
+var errJournalCorrupt = errors.New("journal is corrupt")
+
+// Journal is an append-only WAL bound to a target directory.
+type Journal struct {
+	mu        sync.Mutex
+	dir       string
+	path      string
+	f         *os.File
+	lock      *flock.Flock
+	nextTxnID TxnID
+	inFlight  int
+	closed    bool
+	// recovered is true once this Journal's pre-existing on-disk pending
+	// transactions have been accounted for: either the journal was empty
+	// at Open (nothing to recover) or Recover has completed. Checkpoint and
+	// Close-time truncation refuse to run while it is false, so a non-empty
+	// journal that was opened but never analyzed cannot have its durable
+	// records erased. len(recoveredPending)==0 alone is insufficient here
+	// because a nil map (never recovered) also has length zero.
+	recovered bool
+	// recoveredPending maps each pending TxnID reported by the most recent
+	// Recover() that has not yet been picked up by AdoptTxn to the on-disk
+	// state AdoptTxn needs to reconstruct it. Their records are still
+	// durable on disk and MUST NOT be truncated by Checkpoint or by Close's
+	// clean-shutdown checkpoint; otherwise the next process start has
+	// nothing to replay.
+	recoveredPending map[TxnID]*recoveredTxn
+	// poisoned is set when a failed append could not be rolled back, so a
+	// possibly-complete record may remain on disk. While non-nil every
+	// further append is refused (wrapping ErrJournalPoisoned) to stop a
+	// caller retry from writing a duplicate; it is cleared only by reopening
+	// (a new Journal) or quarantining.
+	poisoned error
+}
+
+// recoveredTxn captures the on-disk state of a pending transaction that
+// Recover observed, so an AdoptTxn'd handle can enforce the same
+// prepared-and-complete commit invariant as a locally-created one.
+type recoveredTxn struct {
+	prepared bool
+	required map[uint32]struct{} // intent step IDs that must be StepDone before commit
+	done     map[uint32]struct{} // steps already durable before adoption
+}
+
+// Open opens (or creates) the journal in dir, acquires an exclusive
+// non-blocking flock on a dedicated lock file (LockFileName),
+// validates the existing journal data file by scanning to the first
+// torn-tail record (which is truncated) and returns the Journal.
+// Mid-stream corruption (bad magic / version / CRC / oversize
+// payload) returns an error without modifying the data file so
+// OpenWithQuarantine can rename it aside.
+//
+// Callers must call Recover once on the returned Journal before any
+// Begin whenever the journal may be non-empty, so newly-issued TxnIDs do
+// not collide with txns already durable on disk. Begin refuses until
+// recovery state is established; a freshly created empty journal is
+// recovered at Open and needs no explicit Recover.
+func Open(dir string) (*Journal, error) {
+	lk, err := acquireDirLock(dir)
+	if err != nil {
+		return nil, err
+	}
+	j, err := openLogLocked(dir, lk)
+	if err != nil {
+		_ = lk.Unlock()
+		return nil, err
+	}
+	return j, nil
+}
+
+// acquireDirLock takes the directory's exclusive non-blocking flock on
+// the dedicated lock file. Returns ErrJournalLocked if another process
+// already holds it, or an errFlockAcquire-marked error if the
+// underlying flock syscall itself failed (e.g. filesystem doesn't
+// support locking, parent directory missing).
+func acquireDirLock(dir string) (*flock.Flock, error) {
+	lockPath := filepath.Join(dir, LockFileName)
+	lk := flock.New(lockPath)
+	ok, err := lk.TryLock()
+	if err != nil {
+		return nil, errors.Mark(errors.Wrap(err, "failed to acquire journal flock"), errFlockAcquire)
+	}
+	if !ok {
+		return nil, ErrJournalLocked
+	}
+	return lk, nil
+}
+
+// openLogLocked opens or creates the journal data file and validates
+// it. The caller must already hold lk and is responsible for releasing
+// it on error or via Journal.Close. On error the data file is closed
+// but lk is left held so the caller can use it for quarantine.
+func openLogLocked(dir string, lk *flock.Flock) (*Journal, error) {
+	path := filepath.Join(dir, FileName)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		werr := errors.Wrap(err, "failed to open journal")
+		// If the journal path exists but is not a regular file (e.g. a
+		// directory occupies it), the on-disk object is unusable as a WAL:
+		// mark it corrupt so OpenWithQuarantine renames it aside. Any other
+		// open failure (EMFILE, EACCES, or ENOENT for a missing parent) is
+		// infrastructure and left unmarked so a healthy file is untouched.
+		if fi, statErr := os.Lstat(path); statErr == nil && !fi.Mode().IsRegular() {
+			werr = errors.Mark(werr, errJournalCorrupt)
+		}
+		return nil, werr
+	}
+	// A journal path that opened successfully but is not a regular file (a
+	// FIFO, device, socket, or a symlink pointing elsewhere) is unusable and
+	// unsafe as a WAL: I/O may block, misbehave, or write outside dir. Reject
+	// it as corrupt so OpenWithQuarantine renames it aside. Check the opened
+	// fd (catches FIFO/device/socket) and the path entry (catches a symlink
+	// whose target is regular) before syncing or validating anything.
+	if fi, statErr := f.Stat(); statErr != nil {
+		_ = f.Close()
+		return nil, errors.Wrap(statErr, "stat journal")
+	} else if !fi.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, errors.Mark(errors.Errorf("journal path is not a regular file (mode %s)", fi.Mode()), errJournalCorrupt)
+	}
+	if li, statErr := os.Lstat(path); statErr != nil {
+		_ = f.Close()
+		return nil, errors.Wrap(statErr, "lstat journal")
+	} else if !li.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, errors.Mark(errors.Errorf("journal path is a symlink or non-regular file (mode %s)", li.Mode()), errJournalCorrupt)
+	}
+	// fsync the parent directory so the journal.log dirent is durable
+	// after a crash. Without this, a freshly-created journal can vanish
+	// even though its records were fsynced individually.
+	if err := syncDir(dir); err != nil {
+		_ = f.Close()
+		return nil, errors.Wrap(err, "sync journal parent directory")
+	}
+	j := &Journal{
+		dir:       dir,
+		path:      path,
+		f:         f,
+		lock:      lk,
+		nextTxnID: 1,
+	}
+	count, err := j.validateAndTruncateTorn()
+	if err != nil {
+		_ = f.Close()
+		// Do NOT release lk; caller (OpenWithQuarantine) may need it
+		// to safely rename the data file aside.
+		return nil, err
+	}
+	// An empty (or fully torn-away) journal has no pre-existing pending
+	// transactions, so it is immediately safe to checkpoint/truncate. A
+	// non-empty journal stays "not recovered" until Recover runs, so its
+	// durable records cannot be erased by Checkpoint or a clean Close
+	// before they have been analyzed.
+	j.recovered = count == 0
+	return j, nil
+}
+
+// syncDir fsyncs a directory so that pending dirent operations (file
+// creates, renames) are made durable.
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = d.Close() }()
+	return d.Sync()
+}
+
+// QuarantineInfo describes a journal file that could not be opened
+// cleanly and was renamed aside so the caller could continue with a
+// fresh empty journal. The original bytes are preserved at
+// QuarantinedPath for offline inspection (e.g. via journal-dump).
+//
+// Retention is the caller's responsibility: the quarantined file (and
+// any journal.log.broken-* siblings from earlier incidents) is never
+// removed by this package, so the caller must surface it to operators
+// and reap it once inspected to avoid unbounded accumulation.
+type QuarantineInfo struct {
+	OriginalPath    string
+	QuarantinedPath string
+	OpenError       error
+}
+
+func (q *QuarantineInfo) Error() string {
+	return fmt.Sprintf("journal quarantined: %s -> %s (cause: %v)",
+		q.OriginalPath, q.QuarantinedPath, q.OpenError)
+}
+
+// OpenWithQuarantine behaves like Open, but if Open fails because the
+// on-disk journal is genuinely unreadable — mid-stream structural
+// corruption (bad magic / version / CRC / oversize payload), or the
+// journal path being occupied by a non-regular file — it renames the
+// existing journal.log to journal.log.broken-<unix-nanos> and retries
+// Open once against a fresh empty file.
+//
+// It deliberately does NOT quarantine on ErrJournalLocked, a flock-layer
+// failure, or any other infrastructure error (EMFILE, EIO, ENOSPC, a
+// missing parent directory, an fsync failure): those leave a
+// possibly-healthy journal untouched so a transient hiccup cannot destroy
+// a good WAL. Semantic broken-writer errors are not detected here at all —
+// Open only validates framing, so a structurally valid but logically
+// impossible stream opens cleanly and is rejected later by
+// Recover/Analyze; use Quarantine to replace such a journal.
+//
+// Concurrency: the dedicated lock file (LockFileName) is held across
+// the whole quarantine operation including the rename and the
+// re-open, so two concurrent callers cannot both rename and produce a
+// split-brain journal. The loser of the race for the lock returns
+// ErrJournalLocked.
+//
+// Return values:
+//   - (j, nil,  nil):  Open succeeded on the first try; no quarantine.
+//   - (j, info, nil):  quarantine occurred, the replacement journal is
+//     j, the renamed-aside path and original error are in info.
+//   - (nil, info, err): quarantine succeeded but the retry Open failed;
+//     the broken file is at info.QuarantinedPath and the caller has
+//     neither a working journal nor a clean slate.
+//   - (nil, nil, err): quarantine refused (ErrJournalLocked, a flock-
+//     layer failure, an infrastructure error, or the source file
+//     disappeared). The on-disk state is unchanged.
+//
+// On a successful quarantine the caller should log loudly and surface
+// the diagnostic path to operators. Quarantining discards in-flight
+// transactions that were durable in the broken file; the caller is
+// responsible for reconciling on-disk state.
+func OpenWithQuarantine(dir string) (*Journal, *QuarantineInfo, error) {
+	lk, err := acquireDirLock(dir)
+	if err != nil {
+		return nil, nil, err
+	}
+	j, openErr := openLogLocked(dir, lk)
+	if openErr == nil {
+		return j, nil, nil
+	}
+	// Only a genuinely unreadable/corrupt journal is renamed aside. An
+	// infrastructure failure (EMFILE, EIO, ENOSPC, a missing parent
+	// directory, an fsync error) must leave the possibly-healthy file
+	// untouched so a transient hiccup cannot destroy a good WAL.
+	if !errors.Is(openErr, errJournalCorrupt) {
+		_ = lk.Unlock()
+		return nil, nil, openErr
+	}
+	return quarantineFileLocked(dir, lk, openErr)
+}
+
+// quarantineFileLocked renames the journal data file aside
+// (journal.log.broken-<unix-nanos>) and reopens a fresh empty journal
+// under the SAME lock lk, held continuously across the rename and re-open
+// so no other process can race in. cause is the error that triggered the
+// quarantine and is recorded in QuarantineInfo.OpenError. On any failure
+// lk is unlocked before returning.
+func quarantineFileLocked(dir string, lk *flock.Flock, cause error) (*Journal, *QuarantineInfo, error) {
+	src := filepath.Join(dir, FileName)
+	dst := filepath.Join(dir, fmt.Sprintf("%s.broken-%d", FileName, time.Now().UnixNano()))
+
+	// Source might be missing (e.g. parent dir gone). With nothing to
+	// rename, surface the original cause.
+	if _, statErr := os.Lstat(src); statErr != nil {
+		_ = lk.Unlock()
+		return nil, nil, cause
+	}
+	if renameErr := os.Rename(src, dst); renameErr != nil {
+		_ = lk.Unlock()
+		return nil, nil, errors.Wrapf(renameErr, "quarantine journal %s -> %s (cause: %v)",
+			src, dst, cause)
+	}
+	// Make the rename itself durable so a crash here doesn't resurrect
+	// the broken file under the original name.
+	if syncErr := syncDir(dir); syncErr != nil {
+		_ = lk.Unlock()
+		return nil, nil, errors.Wrap(syncErr, "sync journal parent directory after quarantine")
+	}
+
+	info := &QuarantineInfo{OriginalPath: src, QuarantinedPath: dst, OpenError: cause}
+	j, retryErr := openLogLocked(dir, lk)
+	if retryErr != nil {
+		_ = lk.Unlock()
+		return nil, info, errors.Wrap(retryErr, "re-open journal after quarantine")
+	}
+	return j, info, nil
+}
+
+// Quarantine renames the journal that j has open aside and reopens a fresh
+// empty journal under the same lock, returning the replacement. It is for a
+// caller whose Recover (or Analyze) reported a broken-writer error: a
+// structurally valid but semantically impossible record stream that Open
+// cannot detect and that retrying OpenWithQuarantine would therefore never
+// replace. The original bytes are preserved at QuarantineInfo.QuarantinedPath
+// for offline inspection; cause is recorded in QuarantineInfo.OpenError.
+//
+// j is consumed: its data-file fd is closed and its lock is transferred to
+// the returned journal, so the caller must stop using j and switch to the
+// returned Journal. j.Close remains safe to call — it becomes a no-op and
+// never releases the transferred lock. On failure the lock is released and
+// j is left closed.
+//
+// Quarantining discards the in-flight transactions that were durable in the
+// broken file; the caller is responsible for reconciling on-disk state.
+func Quarantine(j *Journal, cause error) (*Journal, *QuarantineInfo, error) {
+	j.mu.Lock()
+	if j.closed {
+		j.mu.Unlock()
+		return nil, nil, errors.New("journal is closed")
+	}
+	// Transfer the flock to the replacement: close our fd but do NOT unlock,
+	// so the lock is held continuously across the rename+reopen. Mark this
+	// handle closed and drop its lock reference so its own Close is a no-op
+	// and can never release the transferred lock.
+	lk := j.lock
+	dir := j.dir
+	if j.f != nil {
+		_ = j.f.Close()
+		j.f = nil
+	}
+	j.lock = nil
+	j.closed = true
+	j.mu.Unlock()
+	return quarantineFileLocked(dir, lk, cause)
+}
+
+// validateAndTruncateTorn scans the file from offset 0. A short read at
+// the very end of the file (torn header / torn payload) is truncated
+// away and the file is fsynced; this is the normal crash-recovery path.
+// Any other structural failure (bad magic, unsupported version, bad
+// CRC, oversize payload) is treated as mid-stream corruption and
+// returned as an error so OpenWithQuarantine can rename the file aside
+// for offline inspection rather than silently discarding durable
+// records.
+func (j *Journal) validateAndTruncateTorn() (int, error) {
+	if _, err := j.f.Seek(0, io.SeekStart); err != nil {
+		return 0, err
+	}
+	r := &recordReader{f: j.f}
+	count := 0
+	for {
+		off := r.off
+		_, _, err := r.next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if !errors.Is(err, errTornTail) {
+				return count, errors.Mark(errors.Wrapf(err, "journal corruption at offset %d", off), errJournalCorrupt)
+			}
+			// Torn tail: truncate at the offset where the bad record starts.
+			if errTrunc := j.f.Truncate(off); errTrunc != nil {
+				return count, errors.Wrap(errTrunc, "truncate torn tail")
+			}
+			if errSeek := j.seekEnd(); errSeek != nil {
+				return count, errSeek
+			}
+			if errSync := j.f.Sync(); errSync != nil {
+				return count, errSync
+			}
+			// fsync the parent directory so the truncated length is durable;
+			// matches the create path's syncDir to keep the dirent and file
+			// metadata consistent across crashes.
+			if errDir := syncDir(j.dir); errDir != nil {
+				return count, errors.Wrap(errDir, "sync journal parent directory after truncate")
+			}
+			return count, nil
+		}
+		count++
+	}
+	return count, j.seekEnd()
+}
+
+func (j *Journal) seekEnd() error {
+	_, err := j.f.Seek(0, io.SeekEnd)
+	return err
+}
+
+// Scan returns all records currently in the journal in order. Used by
+// recovery and by the journal-dump CLI. Scan normally observes only
+// records that passed Open's validation; it can however surface a
+// mid-stream corruption error if a write attempt failed and the
+// in-process rollback (truncate+seek+sync after a Write or Sync error)
+// was also unable to clean up (e.g. full disk, EROFS). Callers should
+// treat that the same as Open's corruption surface: stop using the
+// journal and quarantine.
+func (j *Journal) Scan() (out []Record, retErr error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.closed {
+		return nil, errors.New("journal is closed")
+	}
+	if _, err := j.f.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	// Restore the append offset after scanning. A failed re-seek would leave
+	// the next append at the wrong position, so surface it — but only when
+	// the scan itself succeeded, so a real corruption error is not masked.
+	defer func() {
+		if err := j.seekEnd(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
+	r := &recordReader{f: j.f}
+	for {
+		t, payload, err := r.next()
+		if err == io.EOF {
+			return out, nil
+		}
+		if err != nil {
+			// Mid-stream corruption observed after Open succeeded.
+			// This means a prior write attempt failed AND its in-process
+			// truncate/sync rollback also failed (a rare double fault).
+			return out, err
+		}
+		out = append(out, Record{Type: t, Payload: payload})
+	}
+}
+
+// ScanFile reads all complete records from the journal file at path
+// without acquiring the flock. It is intended for read-only debug tools
+// (e.g. journal-dump) that need to inspect a journal that may belong to
+// a running process. A torn tail (short read while reading a
+// header or payload) is treated as a clean end of stream so callers see
+// the same set of records recovery would observe. Mid-stream corruption
+// (bad magic / version / CRC / oversize payload) is surfaced as an
+// error alongside the records read so far.
+//
+// The snapshot is not atomic: because no flock is taken, a concurrent
+// owner may be appending or checkpoint-truncating the file. Callers may
+// therefore observe a torn tail for an in-progress append or a shorter
+// record set straddling a truncation. The view is always bounded and
+// self-consistent up to the returned records; re-run to observe later
+// state.
+func ScanFile(path string) ([]Record, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	var out []Record
+	r := &recordReader{f: f}
+	for {
+		t, payload, err := r.next()
+		if err == io.EOF {
+			return out, nil
+		}
+		if err != nil {
+			if errors.Is(err, errTornTail) {
+				return out, nil
+			}
+			return out, err
+		}
+		out = append(out, Record{Type: t, Payload: payload})
+	}
+}
+
+// Size returns the current journal file size.
+func (j *Journal) Size() (int64, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.closed {
+		return 0, errors.New("journal is closed")
+	}
+	if j.f == nil {
+		return 0, errors.New("journal file is nil")
+	}
+	st, err := j.f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return st.Size(), nil
+}
+
+// Close releases the dedicated-lock-file flock and closes the journal
+// data file's fd. If the journal's recovery state is known (it was empty
+// at Open, or Recover has run) AND no transaction is in flight AND no
+// recovered pending transaction is still awaiting AdoptTxn, Close also
+// writes a final CHECKPOINT and truncates the journal to zero so the next
+// Open starts empty; a checkpoint I/O failure here is non-fatal because
+// the on-disk records remain a valid input for the next Open's recovery.
+// If recovery state is unknown (a non-empty journal was opened but never
+// recovered), or txns are still in flight, or recovered pending txns were
+// never adopted, no checkpoint is attempted so recovery on the next Open
+// can replay them. Safe to call multiple times.
+func (j *Journal) Close() error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.closed {
+		return nil
+	}
+	j.closed = true
+
+	var firstErr error
+	if j.f != nil {
+		if j.recovered && j.inFlight == 0 && len(j.recoveredPending) == 0 {
+			// Best-effort clean checkpoint so the next Open starts empty.
+			// Intentionally do not propagate a checkpoint failure: the
+			// pre-checkpoint records are still durable and recoverable on
+			// the next Open, so the caller's view of "Close succeeded"
+			// remains correct.
+			_ = j.checkpointLocked()
+		}
+		if err := j.f.Close(); err != nil {
+			firstErr = err
+		}
+	}
+	if j.lock != nil {
+		if err := j.lock.Unlock(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// Checkpoint writes a CHECKPOINT record, truncates the journal to zero, and
+// fsyncs. Callers must only checkpoint when no transaction is in flight
+// AND no recovered pending transaction is still awaiting AdoptTxn;
+// otherwise the truncate would discard durable records belonging to
+// in-flight or unadopted recovered txns and crash-recovery would never
+// see them. Checkpoint also refuses until the journal's recovery state is
+// known: on a journal that was non-empty at Open, Recover must run first,
+// so un-analyzed durable pending transactions are never truncated away.
+func (j *Journal) Checkpoint() error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	// Guard here rather than in checkpointLocked: Close sets j.closed before
+	// calling checkpointLocked for its clean-shutdown truncation, so a guard
+	// there would skip it. A public Checkpoint after Close would otherwise
+	// leak an OS closed-file error, and after Quarantine (j.f == nil) reach
+	// appendRecordLocked and panic on the nil file.
+	if j.closed {
+		return errors.New("journal is closed")
+	}
+	return j.checkpointLocked()
+}
+
+func (j *Journal) checkpointLocked() error {
+	if !j.recovered {
+		return errors.New("refusing to checkpoint before recovery state is known; " +
+			"call Recover after Open (a non-empty journal may hold durable pending transactions)")
+	}
+	if j.inFlight > 0 {
+		return errors.Errorf("refusing to checkpoint with %d in-flight transaction(s)", j.inFlight)
+	}
+	if n := len(j.recoveredPending); n > 0 {
+		return errors.Errorf("refusing to checkpoint with %d recovered pending transaction(s) not yet adopted", n)
+	}
+	payload, err := json.Marshal(CheckpointPayload{NextTxnID: j.nextTxnID})
+	if err != nil {
+		return err
+	}
+	if err := j.appendRecordLocked(RecCheckpoint, payload); err != nil {
+		return err
+	}
+	// The CHECKPOINT record above is written and synced before this truncate
+	// on purpose: if we crash in the window between the two, the next Open
+	// still finds a durable CHECKPOINT carrying NextTxnID and an empty
+	// pending set, so recovery is a no-op. After the truncate the file is
+	// simply empty. The extra record per checkpoint is the deliberate cost
+	// of covering that crash window.
+	if err := j.f.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := j.f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	return j.f.Sync()
+}
+
+// Begin starts a new transaction. paramsJSON may be nil. Begin refuses
+// until recovery state is established, because a reopened non-empty
+// journal initializes nextTxnID to 1 and issuing from there would collide
+// with a TxnID already durable on disk and make the journal
+// unrecoverable. A freshly created (empty) journal is recovered at Open,
+// so it needs no explicit Recover; a non-empty journal must first run
+// Recover (or the manual Scan+Analyze+SetNextTxnID path followed by
+// MarkRecovered).
+func (j *Journal) Begin(op Op, paramsJSON []byte) (*Txn, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.closed {
+		return nil, errors.New("journal is closed")
+	}
+	if !j.recovered {
+		return nil, errors.New("refusing to Begin before recovery state is known; " +
+			"call Recover after Open (or the manual Scan+Analyze+SetNextTxnID path then MarkRecovered) " +
+			"so a new TxnID cannot collide with a transaction already durable on disk")
+	}
+	id := j.nextTxnID
+	payload, err := json.Marshal(TxnBeginPayload{TxnID: id, Op: op, Params: paramsJSON})
+	if err != nil {
+		return nil, err
+	}
+	if err := j.appendRecordLocked(RecTxnBegin, payload); err != nil {
+		return nil, err
+	}
+	// Only consume the id and bump bookkeeping after the record is
+	// durably appended; a failed append must not leave an ID hole.
+	j.nextTxnID = id + 1
+	j.inFlight++
+	return &Txn{j: j, id: id, op: op}, nil
+}
+
+// Recover scans the journal, analyzes it, and advances the in-memory
+// next TxnID to the value reported by Analyze. Must be called once on a
+// freshly-opened Journal before any Begin or AdoptTxn so newly-issued
+// TxnIDs do not collide with txns still durable on disk. Recover
+// returns an error if any transaction is already in flight (it would
+// otherwise install a stale recovered-pending snapshot that includes
+// the live txn's id and block all future checkpoint/truncation).
+// Callers should prefer Recover over manually invoking Scan, Analyze,
+// and SetNextTxnID, so a missing SetNextTxnID call cannot cause new
+// Begin transactions to collide with txns that are already durable on
+// disk.
+//
+// Recover also remembers the set of returned pending TxnIDs so that
+// Checkpoint and Close-time truncation will refuse to discard their
+// on-disk records until each one has been picked up by AdoptTxn and
+// resolved (Commit or Abort), and so that AdoptTxn will reject ids that
+// were not actually observed pending on disk. Callers that use the
+// manual Scan+Analyze+SetNextTxnID path do NOT get either safety net.
+func (j *Journal) Recover() (*Analysis, error) {
+	recs, err := j.Scan()
+	if err != nil {
+		return nil, err
+	}
+	a, err := Analyze(recs)
+	if err != nil {
+		return nil, err
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.inFlight > 0 {
+		return nil, errors.Errorf("Recover called with %d in-flight transaction(s); "+
+			"call Recover once on a freshly-opened Journal before any Begin/AdoptTxn", j.inFlight)
+	}
+	if a.NextTxnID > j.nextTxnID {
+		j.nextTxnID = a.NextTxnID
+	}
+	j.recovered = true
+	j.recoveredPending = make(map[TxnID]*recoveredTxn, len(a.Pending))
+	for _, p := range a.Pending {
+		rt := &recoveredTxn{
+			prepared: p.Prepared,
+			required: make(map[uint32]struct{}, len(p.PendingIntents)),
+			done:     make(map[uint32]struct{}, len(p.CompletedSteps)),
+		}
+		for _, in := range p.PendingIntents {
+			rt.required[in.StepID] = struct{}{}
+		}
+		for stepID, ok := range p.CompletedSteps {
+			if ok {
+				rt.done[stepID] = struct{}{}
+			}
+		}
+		j.recoveredPending[p.ID] = rt
+	}
+	return a, nil
+}
+
+// SetNextTxnID forces the next-issued TxnID, monotonically (it never
+// regresses). Recover advances nextTxnID inline; SetNextTxnID is
+// intended for callers that drive the manual Scan + Analyze path
+// instead of Recover. Must be called before any Begin or AdoptTxn.
+// SetNextTxnID alone does not unblock Begin: the manual path must also
+// call MarkRecovered once it has established the next ID.
+func (j *Journal) SetNextTxnID(id TxnID) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if id > j.nextTxnID {
+		j.nextTxnID = id
+	}
+}
+
+// MarkRecovered records that recovery has been completed, unblocking
+// Begin (and permitting Checkpoint / clean-Close truncation). Recover
+// does this itself; MarkRecovered is for callers driving the manual
+// Scan + Analyze + SetNextTxnID path, who must call it once the next
+// TxnID has been established. It does NOT install the recovered-pending
+// safety net, so a manual-path caller remains responsible for not
+// checkpointing away transactions that are still pending on disk.
+func (j *Journal) MarkRecovered() {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.recovered = true
+}
+
+// AdoptTxn returns a Txn handle for an existing in-flight transaction
+// already present in the journal (typically discovered by recovery).
+// The caller is expected to call StepDone for each replayed step and
+// then Commit (or Abort). No TXN_BEGIN is written. Returns an error if
+// the journal has already been closed, if Recover was not called
+// beforehand, or if id is not in the set of pending TxnIDs the most
+// recent Recover() returned (rejecting double-adopt, ids whose
+// COMMIT/ABORT is already durable, and phantom / typo ids whose
+// TXN_BEGIN is not on disk).
+//
+// On success, id is removed from the recovered-pending set so a
+// subsequent Checkpoint or clean Close may truncate the journal once
+// this Txn's Commit/Abort drops inFlight back to zero.
+func AdoptTxn(j *Journal, id TxnID, op Op) (*Txn, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.closed {
+		return nil, errors.New("journal is closed")
+	}
+	rt, ok := j.recoveredPending[id]
+	if !ok {
+		return nil, errors.Errorf("AdoptTxn id %d is not a recovered pending transaction "+
+			"(did you forget to call Recover, already adopt it, or pass a stale id?)", id)
+	}
+	delete(j.recoveredPending, id)
+	j.inFlight++
+	// rt is now orphaned from the map, so its maps can be handed to the Txn.
+	// Seeding prepared/steps/done lets Commit enforce the
+	// prepared-and-complete invariant across the adoption boundary; adopted
+	// marks the handle so Prepare cannot seal a partial post-crash intent set.
+	return &Txn{j: j, id: id, op: op, adopted: true, prepared: rt.prepared, steps: rt.required, done: rt.done}, nil
+}
+
+// appendRecordLocked writes one record and fdatasyncs the journal file.
+// Caller must hold j.mu. If a write or fdatasync fails and the rollback
+// that would remove the partial/complete record also fails, the journal
+// is poisoned: this and all later appends return an ErrJournalPoisoned-
+// marked error so a retry cannot leave a duplicate record on disk.
+func (j *Journal) appendRecordLocked(t RecordType, payload []byte) error {
+	if j.poisoned != nil {
+		return j.poisoned
+	}
+	if len(payload) > MaxPayloadSize {
+		return errors.Errorf("journal record payload too large: %d", len(payload))
+	}
+	buf := make([]byte, headerSize+len(payload))
+	binary.LittleEndian.PutUint32(buf[0:4], magic)
+	binary.LittleEndian.PutUint16(buf[4:6], version)
+	binary.LittleEndian.PutUint16(buf[6:8], uint16(t))
+	binary.LittleEndian.PutUint32(buf[8:12], uint32(len(payload)))
+	// Two independent CRC32C sums: HeaderCRC over the framing (buf[0:12])
+	// protects PayloadLen so recovery can trust it before reading the
+	// payload, and PayloadCRC protects the payload bytes. Keeping them
+	// separate lets recovery distinguish a torn tail from a length whose
+	// bit flip would otherwise swallow the records that follow it.
+	binary.LittleEndian.PutUint32(buf[12:16], crc32.Checksum(buf[0:12], crcTable))
+	binary.LittleEndian.PutUint32(buf[16:20], crc32.Checksum(payload, crcTable))
+	copy(buf[headerSize:], payload)
+
+	// Capture the offset before writing so we can roll back a partial
+	// write. Otherwise, a later successful append would sit after a
+	// torn record and be truncated together with it on next Open.
+	startOff, err := j.f.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return errors.Wrap(err, "journal tell")
+	}
+	if _, err := j.f.Write(buf); err != nil {
+		if rbErr := j.rollbackToLocked(startOff); rbErr != nil {
+			return j.poisonLocked(err, rbErr)
+		}
+		return errors.Wrap(err, "journal write")
+	}
+	// fdatasync (not a full fsync): an append only changes the file's data
+	// plus its size, and fdatasync(2) flushes the size metadata needed to
+	// read the appended bytes back. Skipping the unrelated inode metadata
+	// (mtime/atime) is cheaper on the per-record hot path. Platforms without
+	// fdatasync fall back to a full fsync (see dataSync).
+	if err := dataSync(j.f); err != nil {
+		if rbErr := j.rollbackToLocked(startOff); rbErr != nil {
+			return j.poisonLocked(err, rbErr)
+		}
+		return errors.Wrap(err, "journal sync")
+	}
+	return nil
+}
+
+// poisonLocked records that a failed append could not be rolled back and
+// returns the poison error. Caller must hold j.mu. Both the original
+// append error and the rollback error are captured in the message, and
+// ErrJournalPoisoned is the wrapped cause so callers can detect it via
+// errors.Is and quarantine.
+func (j *Journal) poisonLocked(appendErr, rollbackErr error) error {
+	j.poisoned = errors.Wrapf(ErrJournalPoisoned,
+		"append failed and rollback failed (a possibly-complete record may remain on disk; "+
+			"append error: %v; rollback error: %v)", appendErr, rollbackErr)
+	return j.poisoned
+}
+
+// rollbackToLocked truncates the journal back to off and re-seeks after a
+// failed append. It returns an error if any step fails; the caller must
+// then poison the journal, because a leftover CRC-valid record could be
+// accepted by the next Open and turned into a duplicate operation.
+func (j *Journal) rollbackToLocked(off int64) error {
+	if err := j.f.Truncate(off); err != nil {
+		return err
+	}
+	if _, err := j.f.Seek(off, io.SeekStart); err != nil {
+		return err
+	}
+	return j.f.Sync()
+}
+
+// Txn is a single in-flight transaction.
+type Txn struct {
+	j        *Journal
+	id       TxnID
+	op       Op
+	prepared bool
+	// terminal is the end record (TXN_COMMIT or TXN_ABORT) durably written
+	// for this transaction, or 0 while still in flight. It makes a repeat of
+	// the same outcome idempotent while rejecting the opposite outcome, so a
+	// Commit after a durable Abort (or vice versa) cannot be mistaken for
+	// success.
+	terminal RecordType
+	// adopted marks a handle reconstructed by AdoptTxn from an on-disk
+	// pending transaction. Its intent set is already sealed on disk, so
+	// Prepare is refused: a recovered transaction that was not prepared
+	// before the crash must only be aborted, never sealed and committed.
+	adopted bool
+	// steps is the set of step IDs that must be completed before commit:
+	// intents recorded via Intent, or the recovered intent set for an
+	// adopted transaction.
+	steps map[uint32]struct{}
+	// done is the set of step IDs marked applied via StepDone, seeded with
+	// the already-durable steps for an adopted transaction.
+	done map[uint32]struct{}
+}
+
+// ID returns the transaction id.
+func (t *Txn) ID() TxnID { return t.id }
+
+// Op returns the operation kind.
+func (t *Txn) Op() Op { return t.op }
+
+// Intent records that step stepID with the given action is about to start.
+// argsJSON may be nil. Each stepID must be unique within a transaction; a
+// duplicate returns an error without writing a record, because STEP_DONE
+// completion is keyed by stepID and reusing one would let a single
+// StepDone mask an unapplied step during recovery.
+func (t *Txn) Intent(stepID uint32, action Action, argsJSON []byte) error {
+	t.j.mu.Lock()
+	defer t.j.mu.Unlock()
+	if err := t.checkOpenLocked(); err != nil {
+		return err
+	}
+	// Duplicate step IDs are rejected: STEP_DONE completion is keyed by
+	// StepID, so two intents sharing an ID would be marked done together
+	// and the second could be skipped on crash recovery.
+	if _, dup := t.steps[stepID]; dup {
+		return errors.Errorf("duplicate intent step %d for txn %d", stepID, t.id)
+	}
+	payload, err := json.Marshal(IntentPayload{TxnID: t.id, StepID: stepID, Action: action, Args: argsJSON})
+	if err != nil {
+		return err
+	}
+	if err := t.j.appendRecordLocked(RecIntent, payload); err != nil {
+		return err
+	}
+	if t.steps == nil {
+		t.steps = make(map[uint32]struct{})
+	}
+	t.steps[stepID] = struct{}{}
+	return nil
+}
+
+// StepDone records that step stepID has been durably applied.
+func (t *Txn) StepDone(stepID uint32) error {
+	t.j.mu.Lock()
+	defer t.j.mu.Unlock()
+	if err := t.checkOpenLocked(); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(StepDonePayload{TxnID: t.id, StepID: stepID})
+	if err != nil {
+		return err
+	}
+	if err := t.j.appendRecordLocked(RecStepDone, payload); err != nil {
+		return err
+	}
+	if t.done == nil {
+		t.done = make(map[uint32]struct{})
+	}
+	t.done[stepID] = struct{}{}
+	return nil
+}
+
+// Commit closes the transaction with TXN_COMMIT. It refuses unless the
+// transaction has been prepared and every recorded intent step has a
+// STEP_DONE, mirroring the invariant Analyze enforces on recovery: a
+// premature commit that a later crash truncates before Close would
+// otherwise turn a "successful" operation into an unrecoverable WAL.
+func (t *Txn) Commit() error { return t.end(RecTxnCommit) }
+
+// Abort closes the transaction with TXN_ABORT.
+func (t *Txn) Abort() error { return t.end(RecTxnAbort) }
+
+// Prepare records that the full intent set has been written and the
+// transaction is now safe to redo on recovery. Callers must Prepare
+// after writing every Intent and before Apply'ing the first step.
+// Prepare may only be called once per transaction; a second call
+// returns an error without writing another record. Prepare is also
+// refused on an adopted (recovery-reconstructed) transaction: its
+// intent set is already sealed on disk, so one that was not prepared
+// before the crash must be aborted rather than sealed and committed.
+func (t *Txn) Prepare() error {
+	t.j.mu.Lock()
+	defer t.j.mu.Unlock()
+	if err := t.checkOpenLocked(); err != nil {
+		return err
+	}
+	if t.adopted {
+		return errors.Errorf("refusing to Prepare adopted transaction %d: its intent set is sealed on disk; "+
+			"a recovered transaction not prepared before the crash must be aborted, not committed", t.id)
+	}
+	if t.prepared {
+		return errors.Errorf("transaction %d already prepared", t.id)
+	}
+	payload, err := json.Marshal(TxnEndPayload{TxnID: t.id})
+	if err != nil {
+		return err
+	}
+	if err := t.j.appendRecordLocked(RecTxnPrepare, payload); err != nil {
+		return err
+	}
+	t.prepared = true
+	return nil
+}
+
+// checkOpenLocked verifies the transaction can still accept writes.
+// Caller must hold t.j.mu.
+func (t *Txn) checkOpenLocked() error {
+	if t.j.closed {
+		return errors.New("journal is closed")
+	}
+	if t.terminal != 0 {
+		return errors.New("transaction is closed")
+	}
+	return nil
+}
+
+func (t *Txn) end(rt RecordType) error {
+	t.j.mu.Lock()
+	defer t.j.mu.Unlock()
+	if t.terminal != 0 {
+		// A repeat of the same outcome is idempotent; the opposite outcome is
+		// rejected so an aborted transaction can never be reported committed.
+		if t.terminal == rt {
+			return nil
+		}
+		return errors.Errorf("transaction %d already finished with %s; refusing to apply %s",
+			t.id, t.terminal, rt)
+	}
+	if t.j.closed {
+		return errors.New("journal is closed")
+	}
+	if rt == RecTxnCommit {
+		if !t.prepared {
+			return errors.Errorf("refusing to commit unprepared transaction %d", t.id)
+		}
+		for stepID := range t.steps {
+			if _, ok := t.done[stepID]; !ok {
+				return errors.Errorf("refusing to commit transaction %d with incomplete step %d", t.id, stepID)
+			}
+		}
+	}
+	if rt == RecTxnAbort && t.prepared {
+		// After Prepare, recovery promises to roll the transaction forward, so
+		// a step may already be applied without a durable STEP_DONE. Aborting
+		// would mark it finished and let a checkpoint erase the only replay
+		// plan, leaving partial filesystem state; it must be committed instead.
+		return errors.Errorf("refusing to abort prepared transaction %d: recovery rolls it forward, so it must be committed", t.id)
+	}
+	payload, err := json.Marshal(TxnEndPayload{TxnID: t.id})
+	if err != nil {
+		return err
+	}
+	if err := t.j.appendRecordLocked(rt, payload); err != nil {
+		return err
+	}
+	t.terminal = rt
+	t.j.inFlight--
+	return nil
+}
+
+// recordReader iterates records starting at the current file offset.
+type recordReader struct {
+	f   *os.File
+	off int64
+}
+
+// next reads one record. Returns io.EOF if cleanly past the end. Short
+// reads in the header or payload (consistent with a crash mid-write at
+// the very end of the file) are wrapped with errTornTail so the caller
+// can safely truncate. All other structural failures (bad magic,
+// unsupported version, bad header/payload CRC, oversize payload) return
+// plain errors: the caller is expected to surface those for quarantine
+// rather than silently truncating durable records.
+func (r *recordReader) next() (RecordType, []byte, error) {
+	hdr := make([]byte, headerSize)
+	n, err := io.ReadFull(r.f, hdr)
+	if errors.Is(err, io.EOF) {
+		return 0, nil, io.EOF
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return 0, nil, errors.Wrapf(errTornTail, "torn header: %d bytes at offset %d", n, r.off)
+	}
+	if err != nil {
+		return 0, nil, err
+	}
+	gotMagic := binary.LittleEndian.Uint32(hdr[0:4])
+	if gotMagic != magic {
+		return 0, nil, errors.Errorf("bad magic 0x%08x at offset %d", gotMagic, r.off)
+	}
+	gotVer := binary.LittleEndian.Uint16(hdr[4:6])
+	if gotVer != version {
+		return 0, nil, errors.Errorf("unsupported journal version %d", gotVer)
+	}
+	// Validate the header CRC before trusting PayloadLen. A full header was
+	// read, so a mismatch is genuine mid-stream corruption (e.g. a bit flip
+	// in PayloadLen), NOT a torn tail: returning a plain error routes it to
+	// quarantine instead of reading an inflated length that would consume
+	// and then truncate away the valid records that follow.
+	wantHdrCRC := binary.LittleEndian.Uint32(hdr[12:16])
+	gotHdrCRC := crc32.Checksum(hdr[0:12], crcTable)
+	if gotHdrCRC != wantHdrCRC {
+		return 0, nil, errors.Errorf("bad header CRC at offset %d: got 0x%08x want 0x%08x", r.off, gotHdrCRC, wantHdrCRC)
+	}
+	t := RecordType(binary.LittleEndian.Uint16(hdr[6:8]))
+	plen := binary.LittleEndian.Uint32(hdr[8:12])
+	wantCRC := binary.LittleEndian.Uint32(hdr[16:20])
+	if plen > MaxPayloadSize {
+		return 0, nil, errors.Errorf("payload length %d over cap at offset %d", plen, r.off)
+	}
+	payload := make([]byte, plen)
+	if _, err := io.ReadFull(r.f, payload); err != nil {
+		if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+			return 0, nil, errors.Wrapf(errTornTail, "torn payload at offset %d: %v", r.off, err)
+		}
+		return 0, nil, errors.Wrap(err, "read payload")
+	}
+	gotCRC := crc32.Checksum(payload, crcTable)
+	if gotCRC != wantCRC {
+		return 0, nil, errors.Errorf("bad CRC at offset %d: got 0x%08x want 0x%08x", r.off, gotCRC, wantCRC)
+	}
+	r.off += int64(headerSize) + int64(plen)
+	return t, payload, nil
+}

--- a/wal/journal_test.go
+++ b/wal/journal_test.go
@@ -1,0 +1,1856 @@
+package wal
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func mustOpen(t *testing.T, dir string) *Journal {
+	t.Helper()
+	j, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return j
+}
+
+func TestOpenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() {
+		_ = j.Close()
+	}()
+
+	recs, err := j.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("expected 0 records, got %d", len(recs))
+	}
+}
+
+func TestIntentRejectsDuplicateStepID(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() { _ = j.Close() }()
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionUpdateVolumeMeta, nil); err == nil {
+		t.Fatal("expected error reusing step id 1 within a transaction")
+	}
+	// A different step id is still accepted.
+	if err := tx.Intent(2, ActionUpdateVolumeMeta, nil); err != nil {
+		t.Fatalf("distinct step id must be accepted: %v", err)
+	}
+	// The rejected duplicate must not have been written.
+	recs, err := j.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	intents := 0
+	for _, r := range recs {
+		if r.Type == RecIntent {
+			intents++
+		}
+	}
+	if intents != 2 {
+		t.Fatalf("expected 2 INTENT records, got %d", intents)
+	}
+}
+
+func TestRoundTripTransaction(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+
+	params, _ := json.Marshal(map[string]string{"snapshot": "foo"})
+	tx, err := j.Begin(OpSnapCreate, params)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if tx.ID() != 1 {
+		t.Fatalf("first txn id should be 1, got %d", tx.ID())
+	}
+	args, _ := json.Marshal(map[string]string{"target": "h2"})
+	if err := tx.Intent(1, ActionCreateHead, args); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.StepDone(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Scan before Close so we see the records. The Close below will
+	// checkpoint-and-truncate the file (no in-flight txns), so a Scan
+	// after Close would see an empty journal.
+	recs, err := j.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(recs) != 5 {
+		t.Fatalf("expected 5 records, got %d", len(recs))
+	}
+	if recs[0].Type != RecTxnBegin || recs[4].Type != RecTxnCommit {
+		t.Fatalf("unexpected record sequence: %+v", recs)
+	}
+
+	var begin TxnBeginPayload
+	if err := json.Unmarshal(recs[0].Payload, &begin); err != nil {
+		t.Fatalf("decode begin: %v", err)
+	}
+	if begin.Op != OpSnapCreate || begin.TxnID != 1 {
+		t.Fatalf("bad begin payload: %+v", begin)
+	}
+
+	if err := j.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// After clean close + checkpoint, file is truncated to 0.
+	st, err := os.Stat(filepath.Join(dir, FileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Size() != 0 {
+		t.Fatalf("expected truncated journal, size=%d", st.Size())
+	}
+}
+
+func TestReopenAfterCrash(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.StepDone(1); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate crash: drop fd + flock without checkpoint.
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	j2 := mustOpen(t, dir)
+	defer func() {
+		_ = j2.Close()
+	}()
+	recs, err := j2.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 3 {
+		t.Fatalf("expected 3 records (begin, intent, step_done), got %d", len(recs))
+	}
+}
+
+func TestTornTailTruncated(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	// Append 5 random bytes that look nothing like a record.
+	path := filepath.Join(dir, FileName)
+	stBefore, _ := os.Stat(path)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte{1, 2, 3, 4, 5}); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	j2 := mustOpen(t, dir)
+	defer func() {
+		_ = j2.Close()
+	}()
+	stAfter, _ := os.Stat(path)
+	if stAfter.Size() != stBefore.Size() {
+		t.Fatalf("expected torn tail truncated to %d, got %d", stBefore.Size(), stAfter.Size())
+	}
+	recs, err := j2.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(recs))
+	}
+}
+
+// TestCRCDetectsCorruption verifies that a single corrupted byte in an
+// otherwise-complete record is detected as mid-stream corruption: Open
+// must refuse so OpenWithQuarantine can rename the file aside for
+// inspection rather than silently discarding the durable bytes.
+func TestCRCDetectsCorruption(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	// Flip a byte deep inside the first record's payload.
+	path := filepath.Join(dir, FileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) < headerSize+5 {
+		t.Fatalf("file too short: %d", len(data))
+	}
+	data[headerSize+2] ^= 0xff
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open must refuse mid-stream corruption (no silent truncation).
+	if _, err := Open(dir); err == nil {
+		t.Fatal("expected Open to fail on bad CRC")
+	}
+
+	// File must be untouched: nothing was truncated.
+	stAfter, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int(stAfter.Size()) != len(data) {
+		t.Fatalf("corrupt journal must not be truncated by Open: size=%d want=%d", stAfter.Size(), len(data))
+	}
+
+	// OpenWithQuarantine takes over: file is renamed aside and a fresh
+	// empty journal is opened in its place.
+	j2, info, err := OpenWithQuarantine(dir)
+	if err != nil {
+		t.Fatalf("OpenWithQuarantine: %v", err)
+	}
+	defer func() { _ = j2.Close() }()
+	if info == nil || info.OpenError == nil {
+		t.Fatalf("expected QuarantineInfo with OpenError, got %+v", info)
+	}
+	if _, err := os.Stat(info.QuarantinedPath); err != nil {
+		t.Fatalf("quarantined file must exist: %v", err)
+	}
+	newSize, _ := j2.Size()
+	if newSize != 0 {
+		t.Fatalf("replacement journal should be empty, size=%d", newSize)
+	}
+}
+
+func TestFlockExcludesSecondOpen(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() {
+		_ = j.Close()
+	}()
+
+	if _, err := Open(dir); !errors.Is(err, ErrJournalLocked) {
+		t.Fatalf("expected ErrJournalLocked, got %v", err)
+	}
+}
+
+func TestCheckpointTruncates(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() {
+		_ = j.Close()
+	}()
+
+	tx, _ := j.Begin(OpSnapCreate, nil)
+	_ = tx.Prepare()
+	_ = tx.Commit()
+
+	sz, _ := j.Size()
+	if sz == 0 {
+		t.Fatal("expected non-empty journal before checkpoint")
+	}
+	if err := j.Checkpoint(); err != nil {
+		t.Fatal(err)
+	}
+	sz, _ = j.Size()
+	if sz != 0 {
+		t.Fatalf("expected 0 size after checkpoint, got %d", sz)
+	}
+
+	// nextTxnID should not regress.
+	tx2, _ := j.Begin(OpSnapCreate, nil)
+	if tx2.ID() <= 1 {
+		t.Fatalf("txn ID regressed after checkpoint: %d", tx2.ID())
+	}
+	_ = tx2.Prepare()
+	_ = tx2.Commit()
+}
+
+func TestPrepareThenCrashReplay(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(2, ActionUpdateVolumeMeta, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate crash before any STEP_DONE: drop fd + flock without checkpoint.
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	j2 := mustOpen(t, dir)
+	defer func() { _ = j2.Close() }()
+	a, err := j2.Recover()
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(a.Pending) != 1 {
+		t.Fatalf("expected 1 pending txn, got %d", len(a.Pending))
+	}
+	pt := a.Pending[0]
+	if !pt.Prepared {
+		t.Fatal("expected Prepared=true after PREPARE record")
+	}
+	if len(pt.PendingIntents) != 2 {
+		t.Fatalf("expected 2 intents, got %d", len(pt.PendingIntents))
+	}
+	if len(pt.CompletedSteps) != 0 {
+		t.Fatalf("expected no completed steps, got %v", pt.CompletedSteps)
+	}
+	// Recover must have advanced nextTxnID so a fresh Begin doesn't collide.
+	tx2, err := j2.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tx2.ID() <= pt.ID {
+		t.Fatalf("next txn id %d must be > pending %d", tx2.ID(), pt.ID)
+	}
+	_ = tx2.Abort()
+}
+
+func TestCloseSkipsCheckpointWithInFlightTxn(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Close while the txn is still in flight: records must survive so the
+	// next Open can recover them.
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+	st, err := os.Stat(filepath.Join(dir, FileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Size() == 0 {
+		t.Fatal("expected non-empty journal: in-flight txn must not be checkpointed away")
+	}
+
+	j2 := mustOpen(t, dir)
+	defer func() { _ = j2.Close() }()
+	recs, err := j2.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("expected 2 records (begin, intent), got %d", len(recs))
+	}
+}
+
+func TestCheckpointRejectsInFlightTxn(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() { _ = j.Close() }()
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Checkpoint(); err == nil {
+		t.Fatal("Checkpoint must refuse to run with an in-flight txn")
+	}
+	// Journal must not have been truncated.
+	sz, _ := j.Size()
+	if sz == 0 {
+		t.Fatal("refused checkpoint must leave the journal intact")
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	// After the txn ends, Checkpoint succeeds.
+	if err := j.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint after Commit: %v", err)
+	}
+}
+
+func TestAdoptTxnReplaysPendingTransaction(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(2, ActionUpdateVolumeMeta, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	pendingID := tx.ID()
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	j2 := mustOpen(t, dir)
+	a, err := j2.Recover()
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(a.Pending) != 1 || a.Pending[0].ID != pendingID {
+		t.Fatalf("unexpected recovery: %+v", a.Pending)
+	}
+
+	adopted, err := AdoptTxn(j2, a.Pending[0].ID, a.Pending[0].Op)
+	if err != nil {
+		t.Fatalf("AdoptTxn: %v", err)
+	}
+	for _, intent := range a.Pending[0].PendingIntents {
+		if err := adopted.StepDone(intent.StepID); err != nil {
+			t.Fatalf("StepDone: %v", err)
+		}
+	}
+	if err := adopted.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := j2.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Reopen: no pending txns left, file is truncated by the clean Close.
+	j3 := mustOpen(t, dir)
+	defer func() { _ = j3.Close() }()
+	a, err = j3.Recover()
+	if err != nil {
+		t.Fatalf("Recover #2: %v", err)
+	}
+	if len(a.Pending) != 0 {
+		t.Fatalf("expected no pending after adopted commit, got %+v", a.Pending)
+	}
+}
+
+// TestCommitRejectsUnpreparedTransaction verifies Commit refuses a
+// transaction that was never Prepared. Analyze rejects such a stream as
+// a broken writer, so a successful Commit here would produce a WAL that
+// cannot be recovered after a crash before Close.
+func TestCommitRejectsUnpreparedTransaction(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() { _ = j.Close() }()
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err == nil {
+		t.Fatal("Commit must refuse an unprepared transaction")
+	}
+	// The transaction must still be resolvable via Abort.
+	if err := tx.Abort(); err != nil {
+		t.Fatalf("Abort after refused Commit: %v", err)
+	}
+}
+
+// TestAbortRejectedAfterPrepare verifies that once a transaction is prepared,
+// Abort is refused: recovery promises to roll a prepared txn forward, so a
+// step may already be applied without a durable STEP_DONE. Aborting would let
+// a checkpoint erase the only replay plan, leaving partial filesystem state.
+// The txn must remain in-flight and resolvable by rolling forward to Commit.
+func TestAbortRejectedAfterPrepare(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() { _ = j.Close() }()
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Abort(); err == nil {
+		t.Fatal("Abort must be refused after Prepare")
+	}
+	// The txn stays in-flight and must still be committable by rolling forward.
+	if err := tx.StepDone(1); err != nil {
+		t.Fatalf("StepDone after refused Abort: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit after refused Abort: %v", err)
+	}
+}
+
+// TestCommitRejectsIncompleteTransaction verifies Commit refuses a
+// prepared transaction that still has intents without a matching
+// StepDone, matching Analyze's completeness check.
+func TestCommitRejectsIncompleteTransaction(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() { _ = j.Close() }()
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(2, ActionUpdateVolumeMeta, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	// Only one of the two required steps is done.
+	if err := tx.StepDone(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err == nil {
+		t.Fatal("Commit must refuse a prepared-but-incomplete transaction")
+	}
+	// Completing the last step makes Commit succeed.
+	if err := tx.StepDone(2); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit after completing all steps: %v", err)
+	}
+}
+
+// TestAdoptedCommitEnforcesCompleteness verifies the prepared-and-complete
+// invariant survives the adoption boundary: an AdoptTxn'd handle must
+// refuse Commit until every recovered intent has been replayed via
+// StepDone, then accept it once complete.
+func TestAdoptedCommitEnforcesCompleteness(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(2, ActionUpdateVolumeMeta, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	pendingID := tx.ID()
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	j2 := mustOpen(t, dir)
+	defer func() { _ = j2.Close() }()
+	a, err := j2.Recover()
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(a.Pending) != 1 || a.Pending[0].ID != pendingID {
+		t.Fatalf("unexpected recovery: %+v", a.Pending)
+	}
+
+	adopted, err := AdoptTxn(j2, a.Pending[0].ID, a.Pending[0].Op)
+	if err != nil {
+		t.Fatalf("AdoptTxn: %v", err)
+	}
+	// Neither recovered step has been replayed yet: Commit must refuse.
+	if err := adopted.Commit(); err == nil {
+		t.Fatal("adopted Commit must refuse before recovered steps are replayed")
+	}
+	// Replay one of the two required steps: still incomplete.
+	if err := adopted.StepDone(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := adopted.Commit(); err == nil {
+		t.Fatal("adopted Commit must refuse while a recovered step is still missing")
+	}
+	// Replay the last step: Commit now succeeds.
+	if err := adopted.StepDone(2); err != nil {
+		t.Fatal(err)
+	}
+	if err := adopted.Commit(); err != nil {
+		t.Fatalf("adopted Commit after replaying all steps: %v", err)
+	}
+}
+
+// TestAdoptedUnpreparedTxnCannotPrepare verifies an adopted transaction
+// that was recovered without TXN_PREPARE cannot seal its surviving
+// partial intent prefix via Prepare and commit it. Such a transaction
+// must only be aborted, so Prepare (and therefore Commit) is refused
+// while Abort still resolves it.
+func TestAdoptedUnpreparedTxnCannotPrepare(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Intents are written but the process crashes before TXN_PREPARE.
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	pendingID := tx.ID()
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	j2 := mustOpen(t, dir)
+	defer func() { _ = j2.Close() }()
+	a, err := j2.Recover()
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(a.Pending) != 1 || a.Pending[0].ID != pendingID || a.Pending[0].Prepared {
+		t.Fatalf("expected one unprepared pending txn, got %+v", a.Pending)
+	}
+
+	adopted, err := AdoptTxn(j2, a.Pending[0].ID, a.Pending[0].Op)
+	if err != nil {
+		t.Fatalf("AdoptTxn: %v", err)
+	}
+	// Prepare must be refused: the intent set is sealed on disk and was
+	// never prepared, so it cannot be committed.
+	if err := adopted.Prepare(); err == nil {
+		t.Fatal("Prepare must refuse an adopted unprepared transaction")
+	}
+	// Commit must also be refused (still unprepared).
+	if err := adopted.Commit(); err == nil {
+		t.Fatal("Commit must refuse an adopted unprepared transaction")
+	}
+	// Abort is the only valid resolution.
+	if err := adopted.Abort(); err != nil {
+		t.Fatalf("Abort of adopted unprepared transaction: %v", err)
+	}
+}
+
+// TestOppositeOutcomeAfterTerminalRejected verifies the terminal outcome
+// is sticky: once a transaction is durably aborted, Commit must not
+// return success (which a caller could mistake for a committed
+// operation), and once committed, Abort must be refused. A repeat of the
+// same outcome stays idempotent.
+func TestOppositeOutcomeAfterTerminalRejected(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() { _ = j.Close() }()
+
+	// Aborted transaction: Commit must be refused, repeat Abort is a no-op.
+	aborted, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := aborted.Abort(); err != nil {
+		t.Fatal(err)
+	}
+	if err := aborted.Commit(); err == nil {
+		t.Fatal("Commit after a durable Abort must be refused, not reported as success")
+	}
+	if err := aborted.Abort(); err != nil {
+		t.Fatalf("repeat Abort must stay idempotent: %v", err)
+	}
+
+	// Committed transaction: Abort must be refused, repeat Commit is a no-op.
+	committed, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := committed.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := committed.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := committed.Abort(); err == nil {
+		t.Fatal("Abort after a durable Commit must be refused")
+	}
+	if err := committed.Commit(); err != nil {
+		t.Fatalf("repeat Commit must stay idempotent: %v", err)
+	}
+}
+
+// TestFailedAppendWithFailedRollbackPoisonsJournal verifies that when an
+// append fails and its rollback also fails (so a possibly-complete
+// record may remain on disk), the journal is poisoned: this and every
+// later append are refused with ErrJournalPoisoned so a caller retry
+// cannot write a duplicate/ghost operation.
+func TestFailedAppendWithFailedRollbackPoisonsJournal(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+
+	// Simulate a storage fault where the framed write fails and the
+	// rollback that would remove it also fails: swap the writable fd for a
+	// read-only one. Seek(SeekCurrent) still succeeds (so the append gets
+	// past its offset capture), but Write and the rollback Truncate both
+	// return errors, so the failed append cannot be undone.
+	if err := j.f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	ro, err := os.OpenFile(j.path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j.f = ro
+	t.Cleanup(func() {
+		_ = ro.Close()
+		_ = j.lock.Unlock()
+		j.closed = true
+	})
+
+	// The append fails and cannot be rolled back: the journal is poisoned.
+	if _, err := j.Begin(OpSnapCreate, nil); !errors.Is(err, ErrJournalPoisoned) {
+		t.Fatalf("failed append with failed rollback must poison the journal, got %v", err)
+	}
+	// Every subsequent append is refused with the poison error, even
+	// though the journal was never Close()d.
+	if _, err := j.Begin(OpSnapCreate, nil); !errors.Is(err, ErrJournalPoisoned) {
+		t.Fatalf("poisoned journal must refuse further appends, got %v", err)
+	}
+}
+
+func TestCloseSkipsCheckpointWithUnadoptedRecoveredPending(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	pendingID := tx.ID()
+	// Crash before Commit/Abort.
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen and Recover but do NOT AdoptTxn the pending txn. A clean
+	// Close in this state must not truncate the journal, otherwise the
+	// pending txn becomes invisible to any future process.
+	j2 := mustOpen(t, dir)
+	a, err := j2.Recover()
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(a.Pending) != 1 || a.Pending[0].ID != pendingID {
+		t.Fatalf("unexpected recovery: %+v", a.Pending)
+	}
+	if err := j2.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	st, err := os.Stat(filepath.Join(dir, FileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Size() == 0 {
+		t.Fatal("expected non-empty journal: unadopted recovered pending txn must not be checkpointed away")
+	}
+
+	// Third Open must still see the pending txn so it can be replayed.
+	j3 := mustOpen(t, dir)
+	defer func() { _ = j3.Close() }()
+	a3, err := j3.Recover()
+	if err != nil {
+		t.Fatalf("Recover #3: %v", err)
+	}
+	if len(a3.Pending) != 1 || a3.Pending[0].ID != pendingID {
+		t.Fatalf("third Open lost pending txn: %+v", a3.Pending)
+	}
+}
+
+func TestCheckpointRejectsRecoveredPendingTxn(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	pendingID := tx.ID()
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	j2 := mustOpen(t, dir)
+	defer func() { _ = j2.Close() }()
+	if _, err := j2.Recover(); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if err := j2.Checkpoint(); err == nil {
+		t.Fatal("Checkpoint must refuse to run with an unadopted recovered pending txn")
+	}
+	// Adopt + resolve the pending txn; Checkpoint must then succeed. A
+	// prepared txn can only be rolled forward, so replay its step and commit.
+	adopted, err := AdoptTxn(j2, pendingID, OpSnapCreate)
+	if err != nil {
+		t.Fatalf("AdoptTxn: %v", err)
+	}
+	if err := adopted.StepDone(1); err != nil {
+		t.Fatalf("StepDone: %v", err)
+	}
+	if err := adopted.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := j2.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint after AdoptTxn+Commit: %v", err)
+	}
+}
+
+// TestCloseDoesNotTruncateBeforeRecover verifies that opening a non-empty
+// journal and closing it WITHOUT calling Recover does not checkpoint-and-
+// truncate away durable pending transactions. A nil (never-recovered)
+// recoveredPending map has len 0 but must not be mistaken for "nothing
+// pending".
+func TestCloseDoesNotTruncateBeforeRecover(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	pendingID := tx.ID()
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopen (non-empty) and Close WITHOUT Recover.
+	j2 := mustOpen(t, dir)
+	if err := j2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	st, err := os.Stat(filepath.Join(dir, FileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Size() == 0 {
+		t.Fatal("Close before Recover must not truncate durable pending records")
+	}
+
+	// The pending txn must still be recoverable by a later process.
+	j3 := mustOpen(t, dir)
+	defer func() { _ = j3.Close() }()
+	a, err := j3.Recover()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(a.Pending) != 1 || a.Pending[0].ID != pendingID {
+		t.Fatalf("pending txn lost across Close-before-Recover: %+v", a.Pending)
+	}
+}
+
+// TestCheckpointRefusesBeforeRecover verifies Checkpoint refuses on a
+// non-empty journal whose recovery state has not been established, and
+// succeeds once Recover has run and the pending txn is resolved.
+func TestCheckpointRefusesBeforeRecover(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	j2 := mustOpen(t, dir)
+	defer func() { _ = j2.Close() }()
+	if err := j2.Checkpoint(); err == nil {
+		t.Fatal("Checkpoint must refuse before recovery state is known")
+	}
+	// Journal must be intact after the refused checkpoint.
+	if sz, _ := j2.Size(); sz == 0 {
+		t.Fatal("refused checkpoint must leave the journal intact")
+	}
+
+	a, err := j2.Recover()
+	if err != nil {
+		t.Fatal(err)
+	}
+	adopted, err := AdoptTxn(j2, a.Pending[0].ID, a.Pending[0].Op)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A prepared txn (no intents here) is resolved by rolling it forward.
+	if err := adopted.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := j2.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint after Recover+resolve: %v", err)
+	}
+}
+
+// TestFreshEmptyJournalCheckpointsWithoutRecover confirms the safety gate
+// does not over-fire: a freshly created empty journal has nothing to
+// recover, so Checkpoint and a clean Close are allowed without Recover.
+func TestFreshEmptyJournalCheckpointsWithoutRecover(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint on a fresh journal must be allowed: %v", err)
+	}
+	if sz, _ := j.Size(); sz != 0 {
+		t.Fatalf("expected empty journal after checkpoint, got %d", sz)
+	}
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestBeginRefusedBeforeRecover verifies that reopening a non-empty
+// journal and calling Begin without Recover is rejected, so a fresh
+// TxnID cannot collide with a transaction still durable on disk. After
+// Recover, Begin is allowed and issues a non-colliding id.
+func TestBeginRefusedBeforeRecover(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	pendingID := tx.ID()
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	j2 := mustOpen(t, dir)
+	defer func() { _ = j2.Close() }()
+	if _, err := j2.Begin(OpSnapCreate, nil); err == nil {
+		t.Fatal("Begin must be refused on a non-empty journal before Recover")
+	}
+
+	if _, err := j2.Recover(); err != nil {
+		t.Fatal(err)
+	}
+	tx2, err := j2.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatalf("Begin after Recover: %v", err)
+	}
+	if tx2.ID() <= pendingID {
+		t.Fatalf("next txn id %d must be > durable pending %d", tx2.ID(), pendingID)
+	}
+	_ = tx2.Abort()
+}
+
+// TestManualRecoveryPathMarkRecovered verifies the manual
+// Scan+Analyze+SetNextTxnID path unblocks Begin only after MarkRecovered.
+func TestManualRecoveryPathMarkRecovered(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	pendingID := tx.ID()
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	j2 := mustOpen(t, dir)
+	defer func() { _ = j2.Close() }()
+	recs, err := j2.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := Analyze(recs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j2.SetNextTxnID(a.NextTxnID)
+	// SetNextTxnID alone must not unblock Begin.
+	if _, err := j2.Begin(OpSnapCreate, nil); err == nil {
+		t.Fatal("Begin must stay refused until MarkRecovered on the manual path")
+	}
+	j2.MarkRecovered()
+	tx2, err := j2.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatalf("Begin after MarkRecovered: %v", err)
+	}
+	if tx2.ID() <= pendingID {
+		t.Fatalf("next txn id %d must be > durable %d", tx2.ID(), pendingID)
+	}
+	_ = tx2.Abort()
+}
+
+func TestAdoptTxnFailsOnClosedJournal(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AdoptTxn(j, 1, OpSnapCreate); err == nil {
+		t.Fatal("AdoptTxn must reject a closed journal")
+	}
+}
+
+func TestAdoptTxnRejectsUnknownID(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() { _ = j.Close() }()
+
+	// On a fresh journal nothing has been recovered, so the
+	// recovered-pending set is empty and every id is rejected.
+	if _, err := AdoptTxn(j, 1, OpSnapCreate); err == nil {
+		t.Fatal("AdoptTxn must reject ids not in the recovered-pending set")
+	}
+	if _, err := AdoptTxn(j, 42, OpSnapCreate); err == nil {
+		t.Fatal("AdoptTxn must reject phantom ids")
+	}
+}
+
+func TestAdoptTxnRejectsFinishedID(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finishedID := tx.ID()
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	j2 := mustOpen(t, dir)
+	defer func() { _ = j2.Close() }()
+	a, err := j2.Recover()
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if len(a.Pending) != 0 {
+		t.Fatalf("expected no pending after committed txn, got %+v", a.Pending)
+	}
+	// finishedID < nextTxnID but COMMIT is durable; must NOT be adoptable.
+	if _, err := AdoptTxn(j2, finishedID, OpSnapCreate); err == nil {
+		t.Fatal("AdoptTxn must reject ids whose COMMIT is already durable")
+	}
+}
+
+func TestAdoptTxnRejectsDoubleAdopt(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	pendingID := tx.ID()
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	j2 := mustOpen(t, dir)
+	defer func() { _ = j2.Close() }()
+	if _, err := j2.Recover(); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if _, err := AdoptTxn(j2, pendingID, OpSnapCreate); err != nil {
+		t.Fatalf("first AdoptTxn: %v", err)
+	}
+	if _, err := AdoptTxn(j2, pendingID, OpSnapCreate); err == nil {
+		t.Fatal("second AdoptTxn on the same id must be rejected")
+	}
+}
+
+func TestRecoverRefusesInFlightTxn(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	closed := false
+	defer func() {
+		if !closed {
+			_ = j.Close()
+		}
+	}()
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Recover must refuse: it would otherwise install tx.ID in the
+	// recovered-pending set and never let the journal checkpoint after
+	// tx commits.
+	if _, err := j.Recover(); err == nil {
+		t.Fatal("Recover must refuse to run with an in-flight txn")
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	// After the txn is resolved, Recover succeeds.
+	if _, err := j.Recover(); err != nil {
+		t.Fatalf("Recover after Commit: %v", err)
+	}
+	// And Close can now checkpoint+truncate the journal cleanly.
+	if err := j.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	closed = true
+}
+
+func TestTxnRejectsWritesAfterJournalClose(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Close the journal while the txn is still in flight; subsequent
+	// writes through tx must fail cleanly with "journal is closed"
+	// rather than panicking on a closed *os.File.
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err == nil {
+		t.Fatal("Intent on closed journal must return an error")
+	}
+	if err := tx.StepDone(1); err == nil {
+		t.Fatal("StepDone on closed journal must return an error")
+	}
+	if err := tx.Prepare(); err == nil {
+		t.Fatal("Prepare on closed journal must return an error")
+	}
+	if err := tx.Commit(); err == nil {
+		t.Fatal("Commit on closed journal must return an error")
+	}
+}
+
+func TestPrepareIsNotIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() { _ = j.Close() }()
+
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err == nil {
+		t.Fatal("second Prepare must return an error")
+	}
+	// Only one TXN_PREPARE record should be on disk.
+	recs, err := j.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepCount := 0
+	for _, r := range recs {
+		if r.Type == RecTxnPrepare {
+			prepCount++
+		}
+	}
+	if prepCount != 1 {
+		t.Fatalf("expected exactly 1 TXN_PREPARE record on disk, got %d", prepCount)
+	}
+	_ = tx.Commit()
+}
+
+func TestBeginDoesNotLeakIDOnAppendFailure(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() { _ = j.Close() }()
+
+	// Close the underlying fd so the next appendRecordLocked fails.
+	if err := j.f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := j.Begin(OpSnapCreate, nil); err == nil {
+		t.Fatal("Begin should fail when the underlying fd is closed")
+	}
+	// nextTxnID must not have been bumped.
+	if j.nextTxnID != 1 {
+		t.Fatalf("nextTxnID leaked: got %d want 1", j.nextTxnID)
+	}
+}
+
+// TestOpenWithQuarantineConcurrentRace exercises the rename window:
+// many goroutines race to OpenWithQuarantine the same corrupt journal.
+// Exactly one of them must end up holding a working journal; the
+// others must report a clean error and must not have produced a
+// split-brain (two journal.log inodes claiming to be the live WAL).
+func TestOpenWithQuarantineConcurrentRace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, FileName)
+
+	// Plant a corrupt journal: valid magic+version+payload-len, garbage CRC.
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data[headerSize+2] ^= 0xff
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	const goroutines = 8
+	results := make(chan struct {
+		j    *Journal
+		info *QuarantineInfo
+		err  error
+	}, goroutines)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			jj, info, err := OpenWithQuarantine(dir)
+			results <- struct {
+				j    *Journal
+				info *QuarantineInfo
+				err  error
+			}{jj, info, err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	winners := 0
+	var winner *Journal
+	quarantineCount := 0
+	for r := range results {
+		if r.j != nil {
+			winners++
+			winner = r.j
+		}
+		if r.info != nil {
+			quarantineCount++
+		}
+		if r.err != nil && !errors.Is(r.err, ErrJournalLocked) {
+			t.Errorf("unexpected error from concurrent OpenWithQuarantine: %v", r.err)
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("expected exactly 1 winning OpenWithQuarantine, got %d", winners)
+	}
+	if quarantineCount < 1 {
+		t.Fatalf("expected at least 1 quarantine attempt, got %d", quarantineCount)
+	}
+
+	// The winner must own a fresh, empty, lockable journal.
+	sz, _ := winner.Size()
+	if sz != 0 {
+		t.Fatalf("winner journal should be empty, size=%d", sz)
+	}
+	// No other process can open it.
+	if _, err := Open(dir); !errors.Is(err, ErrJournalLocked) {
+		t.Fatalf("expected ErrJournalLocked from a second Open after race resolution, got %v", err)
+	}
+	_ = winner.Close()
+}
+
+func TestRecordTypeString(t *testing.T) {
+	cases := map[RecordType]string{
+		RecTxnBegin:   "TXN_BEGIN",
+		RecIntent:     "INTENT",
+		RecStepDone:   "STEP_DONE",
+		RecTxnCommit:  "TXN_COMMIT",
+		RecTxnAbort:   "TXN_ABORT",
+		RecCheckpoint: "CHECKPOINT",
+		RecTxnPrepare: "TXN_PREPARE",
+		RecordType(0): "UNKNOWN",
+	}
+	for typ, want := range cases {
+		if got := typ.String(); got != want {
+			t.Errorf("%d: got %q want %q", typ, got, want)
+		}
+	}
+}
+
+func TestScanFileReadOnlyDoesNotTakeFlock(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Journal still open and flocked. ScanFile must not block.
+	path := filepath.Join(dir, FileName)
+	recs, err := ScanFile(path)
+	if err != nil {
+		t.Fatalf("ScanFile: %v", err)
+	}
+	if len(recs) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(recs))
+	}
+	if recs[0].Type != RecTxnBegin || recs[1].Type != RecIntent || recs[2].Type != RecTxnPrepare {
+		t.Fatalf("unexpected types: %+v", recs)
+	}
+	if err := tx.StepDone(1); err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.Commit()
+	_ = j.Close()
+}
+
+func TestScanFileTornTailIsClean(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.StepDone(1); err != nil {
+		t.Fatal(err)
+	}
+	_ = tx.Commit()
+
+	// Drop locks so we can corrupt.
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, FileName)
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Append 7 garbage bytes (less than a header).
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte{1, 2, 3, 4, 5, 6, 7}); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	recs, err := ScanFile(path)
+	if err != nil {
+		t.Fatalf("ScanFile should silently stop at torn tail, got %v", err)
+	}
+	if len(recs) != 5 {
+		t.Fatalf("expected 5 valid records, got %d (size before corruption=%d)", len(recs), st.Size())
+	}
+}
+
+// TestOpenWithQuarantineRenamesUnreadableFile makes journal.log a
+// directory so the underlying os.OpenFile in Open() fails with EISDIR.
+// OpenWithQuarantine should rename it aside and succeed against a
+// fresh empty file.
+func TestOpenWithQuarantineRenamesUnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, FileName)
+
+	// Make the journal path a directory: O_RDWR open fails.
+	if err := os.Mkdir(src, 0700); err != nil {
+		t.Fatal(err)
+	}
+	// Drop a marker inside so we can confirm the original tree is preserved.
+	marker := filepath.Join(src, "marker")
+	if err := os.WriteFile(marker, []byte("evidence"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	j, info, err := OpenWithQuarantine(dir)
+	if err != nil {
+		t.Fatalf("OpenWithQuarantine: %v", err)
+	}
+	defer func() {
+		_ = j.Close()
+	}()
+	if info == nil {
+		t.Fatal("expected QuarantineInfo, got nil")
+	}
+	if info.OpenError == nil {
+		t.Fatal("expected non-nil OpenError")
+	}
+	if info.OriginalPath != src {
+		t.Fatalf("OriginalPath: got %q want %q", info.OriginalPath, src)
+	}
+
+	// Quarantined path must exist with the original contents.
+	st, err := os.Stat(info.QuarantinedPath)
+	if err != nil {
+		t.Fatalf("stat quarantined: %v", err)
+	}
+	if !st.IsDir() {
+		t.Fatal("expected quarantined path to still be the original (dir)")
+	}
+	if _, err := os.Stat(filepath.Join(info.QuarantinedPath, "marker")); err != nil {
+		t.Fatalf("marker missing in quarantined dir: %v", err)
+	}
+	// A new regular journal file should now exist in place of the original.
+	stNew, err := os.Stat(src)
+	if err != nil {
+		t.Fatalf("stat new journal: %v", err)
+	}
+	if stNew.IsDir() {
+		t.Fatal("new journal path should be a regular file, not a directory")
+	}
+
+	// Fresh journal must be writable.
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatalf("Begin on fresh quarantined journal: %v", err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestOpenWithQuarantinePreservesLockError ensures we never quarantine
+// a journal that another process owns.
+func TestOpenWithQuarantinePreservesLockError(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	defer func() {
+		_ = j.Close()
+	}()
+
+	_, info, err := OpenWithQuarantine(dir)
+	if !errors.Is(err, ErrJournalLocked) {
+		t.Fatalf("expected ErrJournalLocked, got %v", err)
+	}
+	if info != nil {
+		t.Fatal("must not quarantine a flock-contended journal")
+	}
+	// Original journal file must still exist with the same name.
+	if _, err := os.Stat(filepath.Join(dir, FileName)); err != nil {
+		t.Fatalf("original journal must be untouched: %v", err)
+	}
+	// No .broken-* sibling created.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), FileName+".broken-") {
+			t.Fatalf("must not produce sibling %q on lock contention", e.Name())
+		}
+	}
+}
+
+// TestOpenWithQuarantineNoFilePropagatesError ensures we don't pretend
+// to quarantine when there's nothing to rename (e.g. parent dir missing
+// or other Open failure unrelated to file content).
+func TestOpenWithQuarantineNoFilePropagatesError(t *testing.T) {
+	// Non-existent directory: Open will fail to create the file.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	_, info, err := OpenWithQuarantine(missing)
+	if err == nil {
+		t.Fatal("expected error for missing parent directory")
+	}
+	if info != nil {
+		t.Fatalf("must not quarantine when source file does not exist; got %+v", info)
+	}
+}
+
+// TestOpenWithQuarantineDoesNotRenameOnInfraError verifies that a healthy,
+// structurally valid journal that merely fails to open for an
+// infrastructure reason (here EACCES from a 0000 mode) is left untouched:
+// no rename aside, no QuarantineInfo. Only genuinely unreadable/corrupt
+// journals may be quarantined, so a transient environmental error cannot
+// destroy a good WAL.
+func TestOpenWithQuarantineDoesNotRenameOnInfraError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("file permission checks are bypassed when running as root")
+	}
+	dir := t.TempDir()
+
+	// A healthy journal with a durable, complete transaction.
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, FileName)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the (regular, healthy) file unopenable: an infrastructure-class
+	// failure, not corruption. It must be preserved, never renamed aside.
+	if err := os.Chmod(path, 0000); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(path, 0600) }()
+
+	jj, info, err := OpenWithQuarantine(dir)
+	if err == nil {
+		_ = jj.Close()
+		t.Fatal("expected an error opening a 0000 journal")
+	}
+	if info != nil {
+		t.Fatalf("must not quarantine a healthy file on an infra error; got %+v", info)
+	}
+
+	// Restore perms and confirm the original bytes are intact and un-renamed.
+	if err := os.Chmod(path, 0600); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("original journal must be intact: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatal("original journal bytes must be unchanged")
+	}
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), FileName+".broken-") {
+			t.Fatalf("must not create a .broken sibling on an infra error; found %q", e.Name())
+		}
+	}
+}
+
+// TestQuarantineReplacesSemanticallyBrokenJournal verifies the explicit
+// post-Recover quarantine path: a stream whose frames are individually
+// valid (so Open succeeds) but whose sequence is logically impossible (a
+// COMMIT without a PREPARE) is only rejected by Recover/Analyze. Quarantine
+// then renames it aside, preserves the bytes, and hands back a fresh,
+// writable journal under the same lock.
+func TestQuarantineReplacesSemanticallyBrokenJournal(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 1, Action: ActionCreateHead}),
+		mkRecord(t, RecStepDone, StepDonePayload{TxnID: 1, StepID: 1}),
+		mkRecord(t, RecTxnCommit, TxnEndPayload{TxnID: 1}),
+	})
+
+	// Open validates framing/CRC only, so it must succeed.
+	j, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// Recover surfaces the broken-writer error that Open could not.
+	_, recErr := j.Recover()
+	if recErr == nil {
+		_ = j.Close()
+		t.Fatal("Recover must reject a COMMIT without PREPARE")
+	}
+
+	fresh, info, qerr := Quarantine(j, recErr)
+	if qerr != nil {
+		t.Fatalf("Quarantine: %v", qerr)
+	}
+	defer func() { _ = fresh.Close() }()
+	if info == nil || info.OpenError == nil {
+		t.Fatalf("expected QuarantineInfo with cause, got %+v", info)
+	}
+	if _, statErr := os.Stat(info.QuarantinedPath); statErr != nil {
+		t.Fatalf("quarantined file must exist: %v", statErr)
+	}
+
+	// The replacement must be a fresh, empty, writable journal.
+	if sz, _ := fresh.Size(); sz != 0 {
+		t.Fatalf("fresh journal must be empty, size=%d", sz)
+	}
+	tx, err := fresh.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatalf("Begin on fresh journal: %v", err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The consumed handle's Close must be a harmless no-op that does NOT
+	// release the lock now owned by the replacement.
+	if err := j.Close(); err != nil {
+		t.Fatalf("consumed handle Close must be a no-op: %v", err)
+	}
+	// The replacement still holds the lock, so a second Open must be refused.
+	if _, err := Open(dir); !errors.Is(err, ErrJournalLocked) {
+		t.Fatalf("expected replacement to still hold the lock, got %v", err)
+	}
+}
+
+// TestOpenRejectsNonRegularJournalPath verifies that a journal path which
+// opens successfully but is not a regular file (here a symlink whose target
+// is a regular file) is rejected as corrupt rather than being used — which
+// could write outside dir. OpenWithQuarantine renames it aside and starts
+// fresh on a real regular file.
+func TestOpenRejectsNonRegularJournalPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "elsewhere")
+	if err := os.WriteFile(target, []byte("not a journal"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, FileName)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open follows the symlink and could open the target, but must refuse.
+	if _, err := Open(dir); err == nil {
+		t.Fatal("Open must refuse a symlink journal path")
+	}
+
+	j, info, err := OpenWithQuarantine(dir)
+	if err != nil {
+		t.Fatalf("OpenWithQuarantine: %v", err)
+	}
+	defer func() { _ = j.Close() }()
+	if info == nil {
+		t.Fatal("expected QuarantineInfo for a non-regular journal path")
+	}
+	// The replacement journal.log must be a regular file.
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fi.Mode().IsRegular() {
+		t.Fatalf("replacement journal must be a regular file, mode=%s", fi.Mode())
+	}
+	tx, err := j.Begin(OpSnapCreate, nil)
+	if err != nil {
+		t.Fatalf("Begin on fresh journal: %v", err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestInflatedPayloadLenDetectedNotTruncated plants an upward bit flip in an
+// earlier record's PayloadLen (still below MaxPayloadSize) that points past
+// EOF. Without an independent header CRC this reads as a torn tail and Open
+// truncates from that record onward, silently dropping the valid records
+// that follow. The header CRC must instead classify it as mid-stream
+// corruption so Open refuses and leaves the file intact for quarantine.
+func TestInflatedPayloadLenDetectedNotTruncated(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	tx, err := j.Begin(OpSnapCreate, []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Intent(1, ActionCreateHead, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Prepare(); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.StepDone(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, FileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	origSize := len(data)
+
+	// Inflate the FIRST record's PayloadLen so it points past EOF but stays
+	// under MaxPayloadSize.
+	binary.LittleEndian.PutUint32(data[8:12], uint32(origSize+4096))
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Open(dir); err == nil {
+		t.Fatal("expected Open to reject an inflated PayloadLen as corruption")
+	}
+	stAfter, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int(stAfter.Size()) != origSize {
+		t.Fatalf("corrupt journal must not be truncated: size=%d want=%d", stAfter.Size(), origSize)
+	}
+}
+
+// TestCheckpointRejectedAfterClose verifies Checkpoint returns a clean
+// "journal is closed" error rather than leaking a lower-level closed-file
+// error from a write to the closed fd.
+func TestCheckpointRejectedAfterClose(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	if err := j.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Checkpoint(); err == nil {
+		t.Fatal("expected Checkpoint to be refused after Close")
+	}
+}
+
+// TestCheckpointRejectedAfterQuarantine verifies Checkpoint on the handle
+// consumed by Quarantine (its file is nil) is refused instead of reaching
+// appendRecordLocked and panicking on the nil file.
+func TestCheckpointRejectedAfterQuarantine(t *testing.T) {
+	dir := t.TempDir()
+	j := mustOpen(t, dir)
+	repl, _, err := Quarantine(j, errors.New("boom"))
+	if err != nil {
+		t.Fatalf("Quarantine: %v", err)
+	}
+	defer func() { _ = repl.Close() }()
+	if err := j.Checkpoint(); err == nil {
+		t.Fatal("expected Checkpoint on the quarantined handle to be refused")
+	}
+}

--- a/wal/recovery.go
+++ b/wal/recovery.go
@@ -1,0 +1,220 @@
+package wal
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/cockroachdb/errors"
+)
+
+// PendingTxn is an unfinished transaction observed by Analyze. The step
+// engine will replay it: each step in CompletedSteps is already durably
+// applied; the next step to execute is the first INTENT whose StepID is
+// not in CompletedSteps. If LastIntent is nil, the transaction crashed
+// before any step started — it can be safely aborted.
+//
+// Prepared is true iff a TXN_PREPARE record was observed for this txn.
+// Recovery must NOT redo a transaction without Prepared, because the
+// intent set may be torn (a crash between two consecutive Intent calls
+// leaves only some intents durable, replaying which would land at an
+// intermediate state). Such transactions should be aborted instead.
+type PendingTxn struct {
+	ID             TxnID
+	Op             Op
+	Params         []byte // raw JSON; op-specific
+	Prepared       bool
+	LastIntent     *IntentPayload
+	CompletedSteps map[uint32]bool
+	PendingIntents []IntentPayload // intents observed in order, including LastIntent
+}
+
+// Analysis is the result of scanning a journal for recovery.
+type Analysis struct {
+	NextTxnID TxnID
+	Pending   []PendingTxn // sorted by TxnID ascending
+}
+
+// Analyze reads all records and returns the set of transactions that need
+// to be replayed or aborted by the step engine.
+func Analyze(records []Record) (*Analysis, error) {
+	type state struct {
+		begin    TxnBeginPayload
+		intents  []IntentPayload
+		seen     map[uint32]bool // INTENT step IDs already observed
+		done     map[uint32]bool
+		prepared bool
+		finished bool
+	}
+	txns := map[TxnID]*state{}
+	var maxTxn TxnID
+
+	for _, rec := range records {
+		switch rec.Type {
+		case RecTxnBegin:
+			var p TxnBeginPayload
+			if err := json.Unmarshal(rec.Payload, &p); err != nil {
+				return nil, errors.Wrap(err, "decode TXN_BEGIN")
+			}
+			if _, exists := txns[p.TxnID]; exists {
+				return nil, errors.Errorf("duplicate TXN_BEGIN for txn %d", p.TxnID)
+			}
+			txns[p.TxnID] = &state{begin: p, seen: map[uint32]bool{}, done: map[uint32]bool{}}
+			if p.TxnID > maxTxn {
+				maxTxn = p.TxnID
+			}
+		case RecIntent:
+			var p IntentPayload
+			if err := json.Unmarshal(rec.Payload, &p); err != nil {
+				return nil, errors.Wrap(err, "decode INTENT")
+			}
+			s, ok := txns[p.TxnID]
+			if !ok {
+				return nil, errors.Errorf("INTENT for unknown txn %d", p.TxnID)
+			}
+			// An intent after the txn is finished, or after PREPARE sealed
+			// the intent set, breaks the prepare boundary: a crash just
+			// before this append would replay a different set than a crash
+			// just after it. Reject the stream as a broken writer.
+			if s.finished {
+				return nil, errors.Errorf("INTENT for finished txn %d", p.TxnID)
+			}
+			if s.prepared {
+				return nil, errors.Errorf("INTENT after TXN_PREPARE for txn %d", p.TxnID)
+			}
+			// Duplicate step IDs are rejected: STEP_DONE completion is keyed
+			// by StepID, so two intents sharing an ID would be marked done
+			// together and the second could be skipped on replay.
+			if s.seen[p.StepID] {
+				return nil, errors.Errorf("duplicate INTENT step %d for txn %d", p.StepID, p.TxnID)
+			}
+			s.seen[p.StepID] = true
+			s.intents = append(s.intents, p)
+		case RecStepDone:
+			var p StepDonePayload
+			if err := json.Unmarshal(rec.Payload, &p); err != nil {
+				return nil, errors.Wrap(err, "decode STEP_DONE")
+			}
+			s, ok := txns[p.TxnID]
+			if !ok {
+				return nil, errors.Errorf("STEP_DONE for unknown txn %d", p.TxnID)
+			}
+			// A STEP_DONE after a terminal record contradicts the stream: the
+			// txn already committed or aborted. STEP_DONE after PREPARE is
+			// normal (steps are applied post-prepare), so only finished is
+			// rejected, mirroring the writer's terminal check.
+			if s.finished {
+				return nil, errors.Errorf("STEP_DONE for finished txn %d", p.TxnID)
+			}
+			s.done[p.StepID] = true
+		case RecTxnCommit:
+			var p TxnEndPayload
+			if err := json.Unmarshal(rec.Payload, &p); err != nil {
+				return nil, errors.Wrap(err, "decode TXN_COMMIT")
+			}
+			s, ok := txns[p.TxnID]
+			if !ok {
+				// No BEGIN for this txn earlier in the stream. This package's
+				// checkpoint truncates the whole file, so a journal it produced
+				// never carries a COMMIT without its BEGIN; tolerate it
+				// defensively (nothing to finish) rather than failing recovery.
+				break
+			}
+			// A COMMIT must seal a fully-completed transaction: it must have
+			// been prepared and every sealed intent must have a STEP_DONE.
+			// A validly framed but premature COMMIT means a broken writer;
+			// erroring (rather than silently dropping the txn from Pending)
+			// forces quarantine instead of losing an unfinished operation.
+			if !s.prepared {
+				return nil, errors.Errorf("TXN_COMMIT for unprepared txn %d", p.TxnID)
+			}
+			for _, in := range s.intents {
+				if !s.done[in.StepID] {
+					return nil, errors.Errorf("TXN_COMMIT for txn %d with incomplete step %d", p.TxnID, in.StepID)
+				}
+			}
+			s.finished = true
+		case RecTxnAbort:
+			var p TxnEndPayload
+			if err := json.Unmarshal(rec.Payload, &p); err != nil {
+				return nil, errors.Wrap(err, "decode TXN_ABORT")
+			}
+			if s, ok := txns[p.TxnID]; ok {
+				// After PREPARE, recovery promises roll-forward, so a durable
+				// ABORT of a prepared txn is a broken writer: a step may have
+				// been applied without its STEP_DONE, and finishing the txn
+				// would let a checkpoint erase the only replay plan. Error to
+				// force quarantine rather than losing partial filesystem state.
+				if s.prepared {
+					return nil, errors.Errorf("TXN_ABORT for prepared txn %d", p.TxnID)
+				}
+				s.finished = true
+			}
+		case RecTxnPrepare:
+			var p TxnEndPayload
+			if err := json.Unmarshal(rec.Payload, &p); err != nil {
+				return nil, errors.Wrap(err, "decode TXN_PREPARE")
+			}
+			s, ok := txns[p.TxnID]
+			if !ok {
+				return nil, errors.Errorf("TXN_PREPARE for unknown txn %d", p.TxnID)
+			}
+			// A PREPARE after the txn already finished (its COMMIT or ABORT is
+			// durable), or a second PREPARE, is a broken writer: the record
+			// stream contradicts itself (e.g. BEGIN -> ABORT -> PREPARE ->
+			// COMMIT records opposite terminal outcomes). Error to force
+			// quarantine rather than silently sealing a contradictory txn.
+			if s.finished {
+				return nil, errors.Errorf("TXN_PREPARE for finished txn %d", p.TxnID)
+			}
+			if s.prepared {
+				return nil, errors.Errorf("duplicate TXN_PREPARE for txn %d", p.TxnID)
+			}
+			s.prepared = true
+		case RecCheckpoint:
+			// A CHECKPOINT in the middle of the stream is unusual but
+			// possible (a writer that did not truncate after writing it).
+			// Pending txns observed before this point are still replayed;
+			// the CHECKPOINT only contributes its NextTxnID hint.
+			var p CheckpointPayload
+			if err := json.Unmarshal(rec.Payload, &p); err != nil {
+				return nil, errors.Wrap(err, "decode CHECKPOINT")
+			}
+			if p.NextTxnID > 0 && p.NextTxnID-1 > maxTxn {
+				maxTxn = p.NextTxnID - 1
+			}
+		default:
+			// A CRC-valid frame with an unknown record type cannot be
+			// interpreted, so recovering (and later checkpointing) it would
+			// erase a record whose semantics we never understood. Reject it
+			// so the journal is preserved for quarantine/inspection.
+			return nil, errors.Errorf("unknown record type %d", rec.Type)
+		}
+	}
+
+	a := &Analysis{NextTxnID: maxTxn + 1}
+	for id, s := range txns {
+		if s.finished {
+			continue
+		}
+		// Copy the completed-steps set so callers can mutate CompletedSteps
+		// without corrupting Analyze's internal state.
+		done := make(map[uint32]bool, len(s.done))
+		for step, ok := range s.done {
+			done[step] = ok
+		}
+		pt := PendingTxn{
+			ID:             id,
+			Op:             s.begin.Op,
+			Params:         s.begin.Params,
+			Prepared:       s.prepared,
+			CompletedSteps: done,
+			PendingIntents: s.intents,
+		}
+		if n := len(s.intents); n > 0 {
+			pt.LastIntent = &s.intents[n-1]
+		}
+		a.Pending = append(a.Pending, pt)
+	}
+	sort.Slice(a.Pending, func(i, j int) bool { return a.Pending[i].ID < a.Pending[j].ID })
+	return a, nil
+}

--- a/wal/recovery_test.go
+++ b/wal/recovery_test.go
@@ -1,0 +1,331 @@
+package wal
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func mkRecord(t *testing.T, typ RecordType, v any) Record {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Record{Type: typ, Payload: b}
+}
+
+// writeJournalFile writes recs to a real on-disk journal in dir using
+// the production framing/CRC/fsync path, then closes it abruptly. After
+// it returns the bytes are durable so a subsequent Open observes exactly
+// these records. Records are appended verbatim (bypassing the Txn API)
+// so recovery-level malformed sequences (e.g. an INTENT without a
+// TXN_BEGIN, or a duplicate TXN_BEGIN) can be laid down on disk.
+func writeJournalFile(t *testing.T, dir string, recs []Record) {
+	t.Helper()
+	j := mustOpen(t, dir)
+	j.mu.Lock()
+	for _, r := range recs {
+		if err := j.appendRecordLocked(r.Type, r.Payload); err != nil {
+			j.mu.Unlock()
+			t.Fatalf("append %s record: %v", r.Type, err)
+		}
+	}
+	j.mu.Unlock()
+	if err := ForceCloseForTest(j); err != nil {
+		t.Fatalf("ForceCloseForTest: %v", err)
+	}
+}
+
+// analyzeJournalFile reopens the on-disk journal in dir, scans the framed
+// records back off disk, and runs Analyze on them. This exercises the
+// full write -> fsync -> reopen -> binary-decode -> analyze path rather
+// than analyzing hand-built in-memory records.
+func analyzeJournalFile(t *testing.T, dir string) (*Analysis, error) {
+	t.Helper()
+	j := mustOpen(t, dir)
+	defer func() { _ = ForceCloseForTest(j) }()
+	recs, err := j.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	return Analyze(recs)
+}
+
+func TestAnalyzeEmpty(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, nil)
+
+	a, err := analyzeJournalFile(t, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(a.Pending) != 0 {
+		t.Fatalf("expected no pending, got %+v", a.Pending)
+	}
+	if a.NextTxnID != 1 {
+		t.Fatalf("expected next id 1, got %d", a.NextTxnID)
+	}
+}
+
+func TestAnalyzeFinishedAndPending(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 1, Action: ActionCreateHead}),
+		mkRecord(t, RecTxnPrepare, TxnEndPayload{TxnID: 1}),
+		mkRecord(t, RecStepDone, StepDonePayload{TxnID: 1, StepID: 1}),
+		mkRecord(t, RecTxnCommit, TxnEndPayload{TxnID: 1}),
+
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 2, Op: OpSnapRevert}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 2, StepID: 1, Action: ActionCreateHead}),
+		mkRecord(t, RecStepDone, StepDonePayload{TxnID: 2, StepID: 1}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 2, StepID: 2, Action: ActionUpdateVolumeMeta}),
+		// crash before STEP_DONE for step 2
+
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 3, Op: OpSnapRemoveMark}),
+		// crash before any intent
+	})
+
+	a, err := analyzeJournalFile(t, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.NextTxnID != 4 {
+		t.Fatalf("next id: got %d want 4", a.NextTxnID)
+	}
+	if len(a.Pending) != 2 {
+		t.Fatalf("expected 2 pending, got %d", len(a.Pending))
+	}
+
+	// Pending[0]: txn 2 — has intent without step_done.
+	p := a.Pending[0]
+	if p.ID != 2 || p.Op != OpSnapRevert {
+		t.Fatalf("pending[0]: %+v", p)
+	}
+	if !p.CompletedSteps[1] || p.CompletedSteps[2] {
+		t.Fatalf("pending[0] completed: %+v", p.CompletedSteps)
+	}
+	if p.LastIntent == nil || p.LastIntent.StepID != 2 {
+		t.Fatalf("pending[0] last intent: %+v", p.LastIntent)
+	}
+
+	// Pending[1]: txn 3 — no intents, safe to abort.
+	p = a.Pending[1]
+	if p.ID != 3 || p.LastIntent != nil {
+		t.Fatalf("pending[1]: %+v", p)
+	}
+}
+
+func TestAnalyzeUnknownTxnID(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 99, StepID: 1, Action: ActionCreateHead}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for INTENT without TXN_BEGIN")
+	}
+}
+
+func TestAnalyzeRejectsDuplicateBegin(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapRevert}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for duplicate TXN_BEGIN")
+	}
+}
+
+func TestAnalyzeRejectsDuplicateIntentStep(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 1, Action: ActionCreateHead}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 1, Action: ActionUpdateVolumeMeta}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for duplicate INTENT step id")
+	}
+}
+
+func TestAnalyzeRejectsCommitWithIncompleteStep(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 1, Action: ActionCreateHead}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 2, Action: ActionUpdateVolumeMeta}),
+		mkRecord(t, RecTxnPrepare, TxnEndPayload{TxnID: 1}),
+		mkRecord(t, RecStepDone, StepDonePayload{TxnID: 1, StepID: 1}),
+		// step 2 never applied
+		mkRecord(t, RecTxnCommit, TxnEndPayload{TxnID: 1}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for TXN_COMMIT with an incomplete step")
+	}
+}
+
+func TestAnalyzeRejectsCommitWithoutPrepare(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 1, Action: ActionCreateHead}),
+		mkRecord(t, RecStepDone, StepDonePayload{TxnID: 1, StepID: 1}),
+		mkRecord(t, RecTxnCommit, TxnEndPayload{TxnID: 1}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for TXN_COMMIT without TXN_PREPARE")
+	}
+}
+
+func TestAnalyzeAbortNeedsNoCompletion(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 1, Action: ActionCreateHead}),
+		mkRecord(t, RecTxnAbort, TxnEndPayload{TxnID: 1}),
+	})
+
+	a, err := analyzeJournalFile(t, dir)
+	if err != nil {
+		t.Fatalf("abort of an incomplete txn must be accepted: %v", err)
+	}
+	if len(a.Pending) != 0 {
+		t.Fatalf("aborted txn must not be pending, got %+v", a.Pending)
+	}
+}
+
+// TestAnalyzeRejectsAbortAfterPrepare verifies that a durable TXN_ABORT for a
+// prepared txn is treated as a broken writer. After PREPARE, recovery promises
+// to roll the txn forward, so a step may have been applied without its
+// STEP_DONE; finishing the txn via abort would let a checkpoint erase the only
+// replay plan. Analyze must error to force quarantine.
+func TestAnalyzeRejectsAbortAfterPrepare(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 1, Action: ActionCreateHead}),
+		mkRecord(t, RecTxnPrepare, TxnEndPayload{TxnID: 1}),
+		mkRecord(t, RecTxnAbort, TxnEndPayload{TxnID: 1}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for TXN_ABORT of a prepared txn")
+	}
+}
+
+// TestAnalyzeRejectsIntentAfterPrepare verifies that an INTENT appended after
+// TXN_PREPARE is treated as a broken writer. PREPARE seals the intent set, so
+// a crash just before the late intent would replay a different set than a
+// crash just after it; Analyze must error to force quarantine.
+func TestAnalyzeRejectsIntentAfterPrepare(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 1, Action: ActionCreateHead}),
+		mkRecord(t, RecTxnPrepare, TxnEndPayload{TxnID: 1}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 2, Action: ActionCreateHead}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for INTENT after TXN_PREPARE")
+	}
+}
+
+// TestAnalyzeRejectsIntentAfterFinished verifies that an INTENT appended after
+// the txn's terminal record is treated as a broken writer.
+func TestAnalyzeRejectsIntentAfterFinished(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 1, Action: ActionCreateHead}),
+		mkRecord(t, RecTxnAbort, TxnEndPayload{TxnID: 1}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 2, Action: ActionCreateHead}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for INTENT after the txn finished")
+	}
+}
+
+// TestAnalyzeRejectsUnknownRecordType verifies that a CRC-valid frame with an
+// unrecognized record type is rejected rather than silently ignored, so
+// recovery cannot checkpoint away a record whose semantics it never
+// understood (a malformed writer or a future format version).
+func TestAnalyzeRejectsUnknownRecordType(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecordType(9999), map[string]int{"x": 1}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for an unknown record type")
+	}
+}
+
+// TestAnalyzeRejectsPrepareForUnknownTxn verifies a TXN_PREPARE with no
+// matching TXN_BEGIN is a broken-writer error rather than being ignored.
+func TestAnalyzeRejectsPrepareForUnknownTxn(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnPrepare, TxnEndPayload{TxnID: 7}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for TXN_PREPARE of an unknown txn")
+	}
+}
+
+// TestAnalyzeRejectsPrepareAfterFinished verifies that BEGIN -> ABORT ->
+// PREPARE is rejected: a PREPARE after the txn already has a durable
+// terminal outcome contradicts the record stream. Left unchecked, a
+// following COMMIT would seal a txn the WAL already aborted.
+func TestAnalyzeRejectsPrepareAfterFinished(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecTxnAbort, TxnEndPayload{TxnID: 1}),
+		mkRecord(t, RecTxnPrepare, TxnEndPayload{TxnID: 1}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for TXN_PREPARE after the txn finished")
+	}
+}
+
+// TestAnalyzeRejectsDuplicatePrepare verifies a second TXN_PREPARE for the
+// same txn is rejected as a broken writer.
+func TestAnalyzeRejectsDuplicatePrepare(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecIntent, IntentPayload{TxnID: 1, StepID: 1, Action: ActionCreateHead}),
+		mkRecord(t, RecTxnPrepare, TxnEndPayload{TxnID: 1}),
+		mkRecord(t, RecTxnPrepare, TxnEndPayload{TxnID: 1}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for a duplicate TXN_PREPARE")
+	}
+}
+
+// TestAnalyzeRejectsStepDoneAfterFinished verifies a STEP_DONE recorded
+// after the txn already has a terminal outcome is a broken-writer error.
+func TestAnalyzeRejectsStepDoneAfterFinished(t *testing.T) {
+	dir := t.TempDir()
+	writeJournalFile(t, dir, []Record{
+		mkRecord(t, RecTxnBegin, TxnBeginPayload{TxnID: 1, Op: OpSnapCreate}),
+		mkRecord(t, RecTxnAbort, TxnEndPayload{TxnID: 1}),
+		mkRecord(t, RecStepDone, StepDonePayload{TxnID: 1, StepID: 1}),
+	})
+
+	if _, err := analyzeJournalFile(t, dir); err == nil {
+		t.Fatal("expected error for STEP_DONE after the txn finished")
+	}
+}

--- a/wal/testing.go
+++ b/wal/testing.go
@@ -1,0 +1,27 @@
+package wal
+
+// ForceCloseForTest drops the underlying fd and releases the flock
+// without writing a final CHECKPOINT. It exists so external test
+// packages can simulate an abrupt process death (SIGKILL) where the
+// journal file is left exactly as it was at the last successful
+// fsync. Production code must use Close().
+func ForceCloseForTest(j *Journal) error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.closed {
+		return nil
+	}
+	j.closed = true
+	var firstErr error
+	if j.f != nil {
+		if err := j.f.Close(); err != nil {
+			firstErr = err
+		}
+	}
+	if j.lock != nil {
+		if err := j.lock.Unlock(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/wal/types.go
+++ b/wal/types.go
@@ -1,0 +1,115 @@
+package wal
+
+// Op identifies a high-level snapshot chain operation.
+type Op string
+
+const (
+	OpSnapCreate     Op = "SNAP_CREATE"
+	OpSnapRevert     Op = "SNAP_REVERT"
+	OpSnapRemove     Op = "SNAP_REMOVE"
+	OpSnapRemoveMark Op = "SNAP_REMOVE_MARK"
+	OpSnapCoalesce   Op = "SNAP_COALESCE"
+	OpSnapPrune      Op = "SNAP_PRUNE"
+	OpSnapReplace    Op = "SNAP_REPLACE"
+	OpHeadDelete     Op = "HEAD_DELETE"
+)
+
+// Action identifies a concrete idempotent filesystem step performed by the
+// step engine. Each Action corresponds to one Apply implementation that the
+// recovery path can replay.
+type Action string
+
+const (
+	ActionCreateHead       Action = "CREATE_HEAD"
+	ActionLinkAsSnapshot   Action = "LINK_AS_SNAPSHOT"
+	ActionUpdateVolumeMeta Action = "UPDATE_VOLUME_META"
+	ActionUpdateSnapMeta   Action = "UPDATE_SNAP_META"
+	ActionDeleteOldHead    Action = "DELETE_OLD_HEAD"
+	ActionRmDisk           Action = "RM_DISK"
+	ActionMarkRemoved      Action = "MARK_REMOVED"
+	ActionCoalesce         Action = "COALESCE"
+	ActionPrune            Action = "PRUNE"
+	ActionReplace          Action = "REPLACE"
+)
+
+// RecordType is the on-disk record kind. Stable values: do not renumber.
+type RecordType uint16
+
+const (
+	RecTxnBegin   RecordType = 1
+	RecIntent     RecordType = 2
+	RecStepDone   RecordType = 3
+	RecTxnCommit  RecordType = 4
+	RecTxnAbort   RecordType = 5
+	RecCheckpoint RecordType = 6
+	// RecTxnPrepare marks the boundary between writing intents and
+	// applying steps. Recovery only redoes a transaction that has a
+	// durable PREPARE; otherwise the intent set might be torn (a
+	// crash between two Intent appends) and replaying it would land
+	// the on-disk state at an intermediate, inconsistent point.
+	RecTxnPrepare RecordType = 7
+)
+
+func (t RecordType) String() string {
+	switch t {
+	case RecTxnBegin:
+		return "TXN_BEGIN"
+	case RecIntent:
+		return "INTENT"
+	case RecStepDone:
+		return "STEP_DONE"
+	case RecTxnCommit:
+		return "TXN_COMMIT"
+	case RecTxnAbort:
+		return "TXN_ABORT"
+	case RecCheckpoint:
+		return "CHECKPOINT"
+	case RecTxnPrepare:
+		return "TXN_PREPARE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// TxnID is a monotonically increasing transaction identifier scoped to the
+// journal file. It resets when the journal is checkpointed/truncated.
+type TxnID uint64
+
+// Record is the in-memory representation of a journal entry. Payload is
+// JSON-encoded for inspectability; the surrounding frame is binary with a
+// CRC so torn tails can be detected.
+type Record struct {
+	Type    RecordType
+	Payload []byte // raw JSON; decode with TxnBeginPayload etc.
+}
+
+// TxnBeginPayload is the payload of a RecTxnBegin record.
+type TxnBeginPayload struct {
+	TxnID  TxnID  `json:"txn_id"`
+	Op     Op     `json:"op"`
+	Params []byte `json:"params,omitempty"` // op-specific JSON
+}
+
+// IntentPayload is the payload of a RecIntent record.
+type IntentPayload struct {
+	TxnID  TxnID  `json:"txn_id"`
+	StepID uint32 `json:"step_id"`
+	Action Action `json:"action"`
+	Args   []byte `json:"args,omitempty"` // action-specific JSON
+}
+
+// StepDonePayload is the payload of a RecStepDone record.
+type StepDonePayload struct {
+	TxnID  TxnID  `json:"txn_id"`
+	StepID uint32 `json:"step_id"`
+}
+
+// TxnEndPayload is the payload of RecTxnCommit and RecTxnAbort records.
+type TxnEndPayload struct {
+	TxnID TxnID `json:"txn_id"`
+}
+
+// CheckpointPayload is the payload of a RecCheckpoint record.
+type CheckpointPayload struct {
+	NextTxnID TxnID `json:"next_txn_id"`
+}


### PR DESCRIPTION

#### Which issue(s) this PR fixes:

Issue Longhorn/longhorn#13259

#### What this PR does / why we need it:

Append-only WAL with binary framing (magic+ver+type+len+CRC32C), fdatasync-per-record durability, gofrs/flock cross-process exclusion, torn-tail truncation on Open, RecTxnPrepare gate for atomic intent-set durability, and OpenWithQuarantine for unreadable-file fallback.
    
Designed to support snapshot-chain transactional recovery for the longhorn-engine replica, but the package is generic.

#### Special notes for your reviewer:

#### Additional documentation or context
