### PR TITLE
fix(kubernetes): detect ext4 emergency_ro mounts as read-only

### DIFF
--- a/kubernetes/mount.go
+++ b/kubernetes/mount.go
@@ -6,7 +6,13 @@ import (
 
 func IsMountPointReadOnly(mp mount.MountPoint) bool {
 	for _, opt := range mp.Opts {
-		if opt == "ro" {
+		// "ro" is the standard read-only mount option. "emergency_ro" is the
+		// ext4 emergency read-only state: since kernel v6.12 (commit
+		// d3476f3dad4a "ext4: don't set SB_RDONLY after filesystem errors"),
+		// errors=remount-ro no longer sets SB_RDONLY, so the mount keeps
+		// showing "rw" while writes fail with EROFS and the state is only
+		// visible as the "emergency_ro" option.
+		if opt == "ro" || opt == "emergency_ro" {
 			return true
 		}
 	}

--- a/kubernetes/mount_test.go
+++ b/kubernetes/mount_test.go
@@ -29,6 +29,20 @@ func TestIsMountPointReadOnly(t *testing.T) {
 			},
 			expected: false,
 		},
+		"EmergencyReadOnly": {
+			// ext4 emergency read-only (kernel >= v6.12): the mount still
+			// shows "rw" but writes fail with EROFS.
+			input: mount.MountPoint{
+				Opts: []string{"rw", "seclabel", "relatime", "emergency_ro"},
+			},
+			expected: true,
+		},
+		"ReadWriteMultipleOpts": {
+			input: mount.MountPoint{
+				Opts: []string{"rw", "seclabel", "relatime"},
+			},
+			expected: false,
+		},
 		"Empty": {
 			input: mount.MountPoint{
 				Opts: []string{},


### PR DESCRIPTION
## Which issue(s) this PR fixes

longhorn/longhorn#13452

## What this PR does / why we need it

Since kernel v6.12 (commit `d3476f3dad4a` "ext4: don't set SB_RDONLY after filesystem errors"), `errors=remount-ro` no longer sets `SB_RDONLY` on filesystem errors. The mount keeps reporting `rw` while writes fail with `EROFS`; the state is only visible as the `emergency_ro` mount option (displayed in `/proc/mounts` since ~v6.15).

`IsMountPointReadOnly()` only matched the literal `ro` option, so on kernel >= 6.12 (e.g. every Talos Linux release since 1.9) the instance-manager never raises the `FilesystemReadOnly` engine condition and longhorn-manager's read-only volume self-heal (longhorn/longhorn#6386) never triggers — workloads crashloop on `EROFS` indefinitely while the volume reports healthy.

This PR treats `emergency_ro` as read-only and adds test cases (including a realistic `rw,seclabel,relatime,emergency_ro` option set, verified live on a Longhorn v1.11.3 / Talos 1.12.7 / kernel 6.18.24 cluster).

Note for the consuming side (can file separately if preferred): `mount -o remount,rw` cannot clear the emergency_ro state since `SB_RDONLY` is unset — once detection works, `requestRemountIfFileSystemReadOnly()` in longhorn-manager should skip the remount attempt (or treat its failure as terminal) and proceed to workload pod deletion so the volume is unstaged and fsck runs at the next NodeStage.

## Special notes for your reviewer

`go test ./kubernetes/ -run TestIsMountPointReadOnly` passes; `gofmt` clean.
