### PR TITLE
fix(exec): kill the process group when command execution times out

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -74,9 +75,18 @@ func (e *Executor) executeCmd(cmd *exec.Cmd, timeout time.Duration) (string, err
 	cmd.Stdout = &output
 	cmd.Stderr = &stderr
 
+	// Place the command in its own process group so that a timeout can kill
+	// the command together with any processes it spawned.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		return "", errors.Wrapf(err, "failed to execute: %v %v, output %s, stderr %s",
+			cmd.Path, cmd.Args, output.String(), stderr.String())
+	}
+
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- cmd.Run()
+		errChan <- cmd.Wait()
 	}()
 
 	select {
@@ -86,6 +96,10 @@ func (e *Executor) executeCmd(cmd *exec.Cmd, timeout time.Duration) (string, err
 				cmd.Path, cmd.Args, output.String(), stderr.String())
 		}
 	case <-ctx.Done():
+		// Kill the process group; otherwise the command would keep running
+		// (and consuming resources) after the timeout error is returned.
+		// The Wait in the goroutine above reaps the process once it exits.
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 		return "", errors.Errorf("timeout executing: %v %v", cmd.Path, cmd.Args)
 	}
 

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -132,4 +133,21 @@ func TestExecuteWithStdinPipe(t *testing.T) {
 
 		})
 	}
+}
+
+func TestExecuteTimeoutKillsProcesses(t *testing.T) {
+	// Unique sleep duration so pgrep only matches processes from this test.
+	const uniqueCommand = "sleep 297.53"
+
+	executor := NewExecutor()
+	// "& wait" makes the shell spawn sleep as a child process, verifying that
+	// the timeout kills the whole process group, not just the direct child.
+	_, err := executor.Execute(nil, "sh", []string{"-c", uniqueCommand + " & wait"}, time.Second)
+	assert.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "timeout executing"))
+
+	// Give the kill a moment to be delivered.
+	time.Sleep(100 * time.Millisecond)
+	err = exec.Command("pgrep", "-f", uniqueCommand).Run()
+	assert.Error(t, err, "processes spawned by the command should be killed after timeout")
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13619

#### What this PR does / why we need it:

`executeCmd()` returns a timeout error but leaves the child process running, so every timed-out invocation leaks a live process; since callers typically retry, leaked processes accumulate, and a busy-looping child permanently consumes CPU inside the caller's cgroup.

This PR starts the command in its own process group and, on timeout, sends SIGKILL to the group so that processes spawned by the command are cleaned up as well. Reaping stays in the existing goroutine, so a child stuck in uninterruptible sleep still does not block the caller.

#### Special notes for your reviewer:

`go test ./exec/` passes, including a new `TestExecuteTimeoutKillsProcesses` that verifies the spawned process tree is gone after a timeout.

The Codespell CI failure is unrelated to this change — it flags `utils/misc.go` (untouched here) and currently fails on other branches as well.

#### Additional documentation or context

None.
